### PR TITLE
PR A: Add RLS and Storage validation runbook

### DIFF
--- a/apps/gold/docs/ops/ROLL_OUT_STATUS_2026-04-23.md
+++ b/apps/gold/docs/ops/ROLL_OUT_STATUS_2026-04-23.md
@@ -1,0 +1,108 @@
+# Rollout Status - 2026-04-23
+
+Estado: operativo / validacion real bloqueada por entorno local.
+
+## Alcance
+
+Rollout end-to-end solicitado para seguridad Supabase, trust pages, Node 20 y health/status.
+
+## Inspeccion rapida
+
+| Item | Resultado |
+| --- | --- |
+| Rama inicial | `main` limpio contra `origin/main` al inicio de la inspeccion |
+| Remote | `https://github.com/YavlPro/YavlGold.git` |
+| Supabase canonico | `supabase/` en raiz |
+| API | `api/health.js` |
+| Vercel | `vercel.json` con rewrite `/health` -> `/api/health` |
+| Node declarado | `package.json` y `apps/gold/package.json` ya exigen `node: 20.x` |
+| Supabase CLI | `2.72.7` |
+| Docker CLI | instalado, pero daemon Docker Desktop no disponible |
+| Supabase project ref local | `gerzlzprkarikblqxpjt` detectado en `supabase/.temp/project-ref` |
+
+## Estado Docker / Supabase local
+
+`supabase start --workdir .` no pudo iniciar porque Docker Desktop/daemon no esta disponible:
+
+```text
+failed to inspect service: dockerDesktopLinuxEngine pipe not found
+```
+
+`docker info` tambien falla con el mismo problema de daemon. Por tanto no se ejecuto `supabase db reset --local --no-seed`.
+
+## Estado staging / remoto
+
+Existe un `project-ref` local, pero `supabase db push --dry-run --workdir .` quedo detenido en `Initialising login role...` y se aborto manualmente para evitar una sesion colgada. No se aplicaron migraciones remotas desde esta sesion.
+
+TODO externo: reintentar staging con sesion Supabase CLI autenticada y red estable.
+
+## Inventario SQL requerido
+
+No se pudo consultar `pg_class`, `pg_policies`, `role_table_grants` ni `storage.buckets` contra una DB viva en esta sesion. La evidencia disponible es estatica por migraciones.
+
+### Tablas owner-scoped detectadas en migraciones
+
+| Recurso | Evidencia estatica | Estado esperado |
+| --- | --- | --- |
+| `profiles` | `001_setup_profiles_trigger.sql` | RLS activo; lectura publica de perfil basico legacy |
+| `agro_feedback` | `20260223183000_agro_feedback.sql` | RLS owner-based select/insert |
+| `agro_buyers`, `agro_farmer_profile` | `20260227000500_agro_profiles.sql` | RLS owner-based |
+| `agro_public_profiles` | `20260227163000_agro_public_profiles.sql` | RLS activo; lectura publica solo cuando `public_enabled = true` |
+| `agro_social_threads`, `agro_social_messages` | `20260227192000_agro_social_v1.sql` | RLS owner-based |
+| `agro_pending`, `agro_income`, `agro_losses`, `agro_expenses`, `agro_transfers` | `20260327001000_agro_facturero_base_order_repair.sql` + `20260420120000_security_trust_hardening_v1.sql` | RLS owner-based reforzado |
+| `agro_task_cycles` | `20260404120000_agro_task_cycles_v1.sql` | RLS owner-based |
+| `agro_period_cycles` | `20260411130000_create_agro_period_cycles.sql` | RLS owner-based |
+| `agro_operational_cycles`, `agro_operational_movements` | `20260416190000_consolidate_legacy_app_supabase_objects.sql` | RLS owner-based |
+| `agro_crops`, `agro_roi_calculations` | `20260417104335_agro_crops_roi_baseline.sql` | RLS owner-based |
+
+### Storage
+
+| Bucket | Evidencia estatica | Estado esperado |
+| --- | --- | --- |
+| `agro-evidence` | `20260420120000_security_trust_hardening_v1.sql` inserta/actualiza `storage.buckets.public = false` | Private |
+| `avatars` | Uso en `apps/gold/assets/js/profile/profileManager.js`; auditoria previa lo marca pendiente de decision UX | TODO externo: confirmar si publico por diseno o migrar a signed URLs |
+
+## Queries para ejecutar en DB viva
+
+```sql
+select n.nspname as schema, c.relname as table, c.relrowsecurity as rls_enabled
+from pg_class c join pg_namespace n on n.oid = c.relnamespace
+where c.relkind='r' and n.nspname='public'
+order by 1,2;
+```
+
+```sql
+select schemaname, tablename, policyname, roles, cmd
+from pg_policies
+where schemaname in ('public','storage')
+order by tablename, policyname;
+```
+
+```sql
+select table_schema, table_name, grantee, privilege_type
+from information_schema.role_table_grants
+where grantee in ('anon','authenticated')
+order by table_schema, table_name;
+```
+
+```sql
+select id, name, public
+from storage.buckets
+order by id;
+```
+
+## Secret scan
+
+Escaneo redaccionado ejecutado sobre el repo excluyendo `node_modules`, `dist` y `.git`.
+
+Resultado:
+
+- No se imprimieron secretos.
+- Coincidencias esperadas: nombres de variables `VITE_SUPABASE_ANON_KEY` en `.env*`, ejemplos y cliente frontend; referencias documentales a `service_role`; grants SQL a rol `service_role`.
+- No se detecto `SUPABASE_SERVICE_ROLE_KEY` activo en frontend ni bundle en esta inspeccion.
+
+## TODOs pendientes por decision externa
+
+- Confirmar si el bucket `avatars` debe seguir publico o migrarse a signed URLs.
+- Reintentar validacion A/B real con Docker Desktop activo o staging autenticado.
+- Confirmar si GitHub private vulnerability reporting esta habilitado en `YavlPro/YavlGold`.

--- a/apps/gold/docs/security/RLS_STORAGE_VALIDATION_2026-04-23.md
+++ b/apps/gold/docs/security/RLS_STORAGE_VALIDATION_2026-04-23.md
@@ -10,7 +10,7 @@ Estado: script reproducible agregado; prueba A/B real no ejecutada por bloqueo d
 | Staging Supabase | `project-ref` detectado, pero `supabase db push --dry-run` quedo colgado en inicializacion |
 | Migraciones aplicadas en esta sesion | Ninguna |
 | Script reproducible | `tools/rls-smoke-test.js` |
-| Commit | Completar al cerrar rama |
+| Commit | Ver ultimo commit de la rama `codex/2026-04-23-prA-rls-validation` |
 
 ## Script A/B
 

--- a/apps/gold/docs/security/RLS_STORAGE_VALIDATION_2026-04-23.md
+++ b/apps/gold/docs/security/RLS_STORAGE_VALIDATION_2026-04-23.md
@@ -1,0 +1,92 @@
+# RLS + Storage Validation - 2026-04-23
+
+Estado: script reproducible agregado; prueba A/B real no ejecutada por bloqueo de entorno.
+
+## Entorno
+
+| Item | Resultado |
+| --- | --- |
+| Local Supabase | Bloqueado: Docker Desktop/daemon no disponible |
+| Staging Supabase | `project-ref` detectado, pero `supabase db push --dry-run` quedo colgado en inicializacion |
+| Migraciones aplicadas en esta sesion | Ninguna |
+| Script reproducible | `tools/rls-smoke-test.js` |
+| Commit | Completar al cerrar rama |
+
+## Script A/B
+
+El script usa solo `SUPABASE_URL` y `SUPABASE_ANON_KEY` desde entorno. No requiere ni acepta `service_role`.
+
+Variables:
+
+```bash
+SUPABASE_URL=...
+SUPABASE_ANON_KEY=...
+SUPABASE_USER_A_EMAIL=...
+SUPABASE_USER_A_PASSWORD=...
+SUPABASE_USER_B_EMAIL=...
+SUPABASE_USER_B_PASSWORD=...
+RLS_SMOKE_TABLE=agro_pending
+RLS_SMOKE_BUCKET=agro-evidence
+node tools/rls-smoke-test.js
+```
+
+Alternativa con JWT manuales:
+
+```bash
+SUPABASE_USER_A_ACCESS_TOKEN=...
+SUPABASE_USER_B_ACCESS_TOKEN=...
+node tools/rls-smoke-test.js
+```
+
+## Matriz de validacion esperada
+
+| Recurso | Select own | Select cross-user | Insert wrong user_id | Update cross-user | Delete cross-user | Storage own upload | Storage cross upload | Storage cross read |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `agro_pending` + `agro-evidence` | TODO ejecutar | TODO ejecutar | TODO ejecutar | TODO ejecutar | TODO ejecutar | TODO ejecutar | TODO ejecutar | TODO ejecutar |
+
+## Evidencia estatica
+
+- `supabase/migrations/20260420120000_security_trust_hardening_v1.sql` fuerza `agro-evidence` como bucket privado.
+- Esa misma migracion crea policies `agro_evidence_select_own`, `insert_own`, `update_own`, `delete_own` con prefijo `(select auth.uid())::text`.
+- Esa misma migracion refuerza RLS owner-based para `agro_pending`, `agro_income`, `agro_losses`, `agro_expenses`, `agro_transfers`.
+- El frontend normaliza paths de `agro-evidence` en `apps/gold/agro/agro.js` para conservar el prefijo del usuario.
+
+## Resultado de esta sesion
+
+| Prueba | Resultado | Evidencia |
+| --- | --- | --- |
+| `supabase start --workdir .` | FAIL | Docker Desktop pipe no disponible |
+| `supabase db reset --local --no-seed` | NO EJECUTADO | depende de Docker local |
+| `supabase db push --dry-run --workdir .` | ABORTADO | quedo en `Initialising login role...` |
+| A/B DB real | NO EJECUTADO | requiere local o staging operativo |
+| A/B Storage real | NO EJECUTADO | requiere local o staging operativo |
+
+## Runbook para cerrar validacion real
+
+1. Iniciar Docker Desktop.
+2. Ejecutar:
+
+```bash
+supabase start --workdir .
+supabase db reset --workdir . --local --no-seed
+```
+
+3. Crear dos usuarios QA A/B o usar dos usuarios existentes de staging.
+4. Ejecutar:
+
+```bash
+SUPABASE_URL=<url> \
+SUPABASE_ANON_KEY=<anon> \
+SUPABASE_USER_A_EMAIL=<qa-a> \
+SUPABASE_USER_A_PASSWORD=<password-a> \
+SUPABASE_USER_B_EMAIL=<qa-b> \
+SUPABASE_USER_B_PASSWORD=<password-b> \
+node tools/rls-smoke-test.js
+```
+
+5. Pegar el JSON resultante en esta seccion y cambiar la matriz de `TODO ejecutar` a `ok`/`blocked`.
+
+## TODOs pendientes
+
+- Ejecutar A/B real cuando haya DB viva.
+- Confirmar bucket `avatars` como publico por diseno o migrarlo a policies privadas.

--- a/tools/rls-smoke-test.js
+++ b/tools/rls-smoke-test.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+const { createClient } = require('@supabase/supabase-js');
+
+const required = ['SUPABASE_URL', 'SUPABASE_ANON_KEY'];
+const missing = required.filter((name) => !process.env[name]);
+
+if (missing.length > 0) {
+  console.error(`Missing required env: ${missing.join(', ')}`);
+  process.exit(2);
+}
+
+const config = {
+  url: process.env.SUPABASE_URL,
+  anonKey: process.env.SUPABASE_ANON_KEY,
+  table: process.env.RLS_SMOKE_TABLE || 'agro_pending',
+  bucket: process.env.RLS_SMOKE_BUCKET || 'agro-evidence',
+  runId: process.env.RLS_SMOKE_RUN_ID || `rls-smoke-${Date.now()}`
+};
+
+function decodeJwtSub(token) {
+  if (!token || token.split('.').length < 2) return null;
+  const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+  const json = Buffer.from(payload, 'base64').toString('utf8');
+  return JSON.parse(json).sub || null;
+}
+
+function clientWithOptionalToken(token) {
+  return createClient(config.url, config.anonKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false
+    },
+    global: token
+      ? { headers: { Authorization: `Bearer ${token}` } }
+      : undefined
+  });
+}
+
+async function createUserSession(label) {
+  const token = process.env[`SUPABASE_USER_${label}_ACCESS_TOKEN`];
+  if (token) {
+    const client = clientWithOptionalToken(token);
+    return { client, user: { id: decodeJwtSub(token) }, label };
+  }
+
+  const email = process.env[`SUPABASE_USER_${label}_EMAIL`];
+  const password = process.env[`SUPABASE_USER_${label}_PASSWORD`];
+  if (!email || !password) {
+    throw new Error(
+      `Missing credentials for user ${label}. Provide SUPABASE_USER_${label}_ACCESS_TOKEN or SUPABASE_USER_${label}_EMAIL/PASSWORD.`
+    );
+  }
+
+  const client = clientWithOptionalToken();
+  const { data, error } = await client.auth.signInWithPassword({ email, password });
+  if (error) throw new Error(`User ${label} login failed: ${error.message}`);
+  return { client, user: data.user, label };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function rowPayload(userId, label) {
+  return {
+    user_id: userId,
+    concepto: `${config.runId}-${label}`,
+    cliente: `rls-smoke-${label}`,
+    monto: 1,
+    currency: 'USD',
+    transfer_state: 'active'
+  };
+}
+
+async function insertRow(session, payload) {
+  const { data, error } = await session.client
+    .from(config.table)
+    .insert(payload)
+    .select('id,user_id')
+    .single();
+
+  if (error) throw new Error(`${session.label} insert failed on ${config.table}: ${error.message}`);
+  return data;
+}
+
+async function expectDeniedOrNoRows(operation, description) {
+  const { data, error } = await operation();
+  const rowCount = Array.isArray(data) ? data.length : data ? 1 : 0;
+  assert(Boolean(error) || rowCount === 0, `${description} unexpectedly succeeded`);
+  return { blocked: true, error: error?.message || null, rows: rowCount };
+}
+
+async function cleanupRow(session, id) {
+  if (!id) return;
+  await session.client.from(config.table).delete().eq('id', id);
+}
+
+async function storageUpload(session, path, label) {
+  const body = new Blob([`${config.runId}:${label}`], { type: 'text/plain' });
+  return session.client.storage.from(config.bucket).upload(path, body, {
+    contentType: 'text/plain',
+    upsert: false
+  });
+}
+
+async function storageRemove(session, paths) {
+  if (!paths.length) return;
+  await session.client.storage.from(config.bucket).remove(paths);
+}
+
+async function run() {
+  const a = await createUserSession('A');
+  const b = await createUserSession('B');
+
+  assert(a.user?.id, 'User A id unavailable');
+  assert(b.user?.id, 'User B id unavailable');
+  assert(a.user.id !== b.user.id, 'Users A and B must be different accounts');
+
+  const results = [];
+  let aRow = null;
+  let bRow = null;
+  const aPath = `${a.user.id}/agro/income/${config.runId}-a.txt`;
+  const bPath = `${b.user.id}/agro/income/${config.runId}-b.txt`;
+  const crossPath = `${b.user.id}/agro/income/${config.runId}-cross.txt`;
+
+  try {
+    aRow = await insertRow(a, rowPayload(a.user.id, 'A'));
+    bRow = await insertRow(b, rowPayload(b.user.id, 'B'));
+    results.push(['db_insert_own', 'ok']);
+
+    const ownRead = await a.client.from(config.table).select('id,user_id').eq('id', aRow.id);
+    assert(!ownRead.error && ownRead.data?.length === 1, 'User A could not read own row');
+    results.push(['db_select_own', 'ok']);
+
+    const crossRead = await a.client.from(config.table).select('id,user_id').eq('id', bRow.id);
+    assert(!crossRead.error && crossRead.data.length === 0, 'User A read user B row');
+    results.push(['db_select_cross_user', 'blocked']);
+
+    await expectDeniedOrNoRows(
+      () => a.client.from(config.table).update({ concepto: `${config.runId}-cross-update` }).eq('id', bRow.id).select('id'),
+      'User A update of user B row'
+    );
+    results.push(['db_update_cross_user', 'blocked']);
+
+    await expectDeniedOrNoRows(
+      () => a.client.from(config.table).delete().eq('id', bRow.id).select('id'),
+      'User A delete of user B row'
+    );
+    results.push(['db_delete_cross_user', 'blocked']);
+
+    await expectDeniedOrNoRows(
+      () => a.client.from(config.table).insert(rowPayload(b.user.id, 'A-as-B')).select('id'),
+      'User A insert with user B user_id'
+    );
+    results.push(['db_insert_wrong_user_id', 'blocked']);
+
+    const ownUpload = await storageUpload(a, aPath, 'A');
+    if (ownUpload.error) throw new Error(`User A own storage upload failed: ${ownUpload.error.message}`);
+    results.push(['storage_upload_own', 'ok']);
+
+    const bUpload = await storageUpload(b, bPath, 'B');
+    if (bUpload.error) throw new Error(`User B own storage upload failed: ${bUpload.error.message}`);
+    results.push(['storage_upload_b_own_setup', 'ok']);
+
+    const crossUpload = await storageUpload(a, crossPath, 'A-to-B');
+    assert(Boolean(crossUpload.error), 'User A uploaded into user B storage prefix');
+    results.push(['storage_upload_cross_prefix', 'blocked']);
+
+    const crossDownload = await a.client.storage.from(config.bucket).download(bPath);
+    assert(Boolean(crossDownload.error), 'User A downloaded user B storage object');
+    results.push(['storage_read_cross_prefix', 'blocked']);
+  } finally {
+    await cleanupRow(a, aRow?.id);
+    await cleanupRow(b, bRow?.id);
+    await storageRemove(a, [aPath]);
+    await storageRemove(b, [bPath]);
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    table: config.table,
+    bucket: config.bucket,
+    runId: config.runId,
+    results: Object.fromEntries(results)
+  }, null, 2));
+}
+
+run().catch((error) => {
+  console.error(JSON.stringify({ ok: false, error: error.message }, null, 2));
+  process.exit(1);
+});


### PR DESCRIPTION
## Riesgo mitigado

RLS/Storage no verificable reproduciblemente y riesgo de cross-user sin evidencia A/B.

## Cambios

- Agrega `tools/rls-smoke-test.js` para pruebas A/B con `SUPABASE_URL` + `SUPABASE_ANON_KEY` y usuarios/JWTs QA, sin `service_role`.
- Documenta estado Docker/Supabase, project-ref detectado, inventario estatico y queries SQL en `apps/gold/docs/ops/ROLL_OUT_STATUS_2026-04-23.md`.
- Documenta matriz y runbook en `apps/gold/docs/security/RLS_STORAGE_VALIDATION_2026-04-23.md`.
- Rebasado sobre `origin/main` despues del merge de PR #84; `AGENT_REPORT_ACTIVE.md` queda igual que `main` para evitar conflictos documentales.

## Pruebas

- `node tools/rls-smoke-test.js` sin env -> falla esperado por falta de `SUPABASE_URL` y `SUPABASE_ANON_KEY`, sin imprimir secretos.
- `pnpm build:gold` -> OK.
- `git diff --check` -> OK.
- `git merge-tree --write-tree origin/main codex/2026-04-23-prA-rls-validation` -> OK.

## Pendiente externo

Docker Desktop no estuvo disponible y `supabase db push --dry-run --workdir .` quedo detenido en staging; la validacion A/B real debe ejecutarse cuando exista DB local o staging autenticado.