### PR TITLE
PR B: Resolve public trust placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@ This file follows the spirit of Keep a Changelog and keeps release notes useful 
 
 ### Changed
 
-- [PENDIENTE] Document production decisions such as `SECURITY_EMAIL`, public repository URL, and legal jurisdiction.
+- Documented production trust defaults: security contact `soporte@yavlgold.com`, public repository `https://github.com/YavlPro/YavlGold`, Venezuelan applicable-law wording, and operational response targets.
 
 ### Fixed
 
-- [PENDIENTE]
+- Removed visible trust-page placeholders and added a public security page to the Vite MPA build.
 
 ### Security
 
-- [PENDIENTE] Confirm RLS/Storage checks against production with two QA users before marking hardening fully closed.
+- Added reproducible RLS/Storage validation runbook and smoke-test script for two-user A/B checks.
 
 ## [1.0.0] - 2026-04-20
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ MIT License. Ver `LICENSE`.
 
 ## Open Source y confianza
 
-- Repositorio publico: `https://github.com/ORG/REPO` [PENDIENTE]
+- Repositorio publico: `https://github.com/YavlPro/YavlGold`
 - Pagina Open Source: `apps/gold/open-source.html`
+- Politica de seguridad: `SECURITY.md` y `apps/gold/security.html`
 - Aviso anti-suplantacion/no inversiones: `apps/gold/anti-suplantacion.html`
 - YavlGold no vende oro, no administra inversiones y no solicita dinero por canales no oficiales.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,8 @@ Do not open public GitHub issues for vulnerabilities.
 
 Use one of these private channels:
 
-- `SECURITY_EMAIL` [PENDIENTE]
-- GitHub private vulnerability reporting [PENDIENTE: habilitar si el repo es publico]
+- Email: `soporte@yavlgold.com` with subject `Seguridad`.
+- GitHub private vulnerability reporting only if it is visibly enabled in the public repository UI.
 
 Include:
 

--- a/apps/gold/anti-suplantacion.html
+++ b/apps/gold/anti-suplantacion.html
@@ -58,7 +58,7 @@
           </div>
           <div class="trust-meta">
             <span>Repositorio</span>
-            <strong>Aun no publicado publicamente</strong>
+            <strong><a href="https://github.com/YavlPro/YavlGold" target="_blank" rel="noopener noreferrer">github.com/YavlPro/YavlGold</a></strong>
           </div>
           <div class="trust-meta">
             <span>Soporte</span>
@@ -85,6 +85,7 @@
         <a href="/#register" class="trust-button trust-button--primary">Comenzar Ahora</a>
         <a href="/" class="trust-button">Volver al inicio</a>
         <a href="/open-source" class="trust-button">Open Source</a>
+        <a href="/security" class="trust-button">Seguridad</a>
         <a href="/privacy" class="trust-button">Privacidad</a>
       </div>
     </div>
@@ -102,6 +103,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/cookies.html
+++ b/apps/gold/cookies.html
@@ -97,6 +97,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/docs-agro.html
+++ b/apps/gold/docs-agro.html
@@ -406,6 +406,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/docs/ops/INCIDENT_RESPONSE_RUNBOOK.md
+++ b/apps/gold/docs/ops/INCIDENT_RESPONSE_RUNBOOK.md
@@ -52,10 +52,10 @@ Cada incidente cerrado debe registrar:
 
 - Vercel: alertas de 5xx y despliegues fallidos.
 - Supabase: errores Auth, Edge Function failures y actividad anomala.
-- Sentry u observabilidad equivalente: [PENDIENTE si se adopta].
+- Sentry u observabilidad equivalente: no configurado como requisito operativo activo; documentar aqui antes de adoptarlo.
 
 ## Pendientes
 
 - Definir canal interno de guardia.
-- Definir `SECURITY_EMAIL`.
+- Confirmar si se habilita GitHub private vulnerability reporting ademas del canal `soporte@yavlgold.com`.
 - Definir politica de postmortem publico vs interno.

--- a/apps/gold/faq.html
+++ b/apps/gold/faq.html
@@ -99,6 +99,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/index.html
+++ b/apps/gold/index.html
@@ -427,6 +427,8 @@
           <a href="/open-source"><i class="fa-solid fa-scale-balanced" aria-hidden="true"></i> Licencia MIT</a>
           <a href="/privacy"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i> Política de datos</a>
           <a href="/terms"><i class="fa-solid fa-file-export" aria-hidden="true"></i> Términos de uso</a>
+          <a href="/security"><i class="fa-solid fa-lock" aria-hidden="true"></i> Seguridad</a>
+          <a href="/anti-suplantacion"><i class="fa-solid fa-user-shield" aria-hidden="true"></i> Anti-suplantación</a>
         </div>
         <div class="footer-col">
           <h5><i class="fa-solid fa-code" aria-hidden="true" style="margin-right:var(--comp-icon-gap);font-size:var(--icon-sm);color:var(--gold-4);"></i> Proyecto</h5>

--- a/apps/gold/open-source.html
+++ b/apps/gold/open-source.html
@@ -43,7 +43,7 @@
     <div class="trust-panel">
       <section class="trust-section">
         <h2>Repositorio</h2>
-        <p>El codigo fuente se mantiene bajo licencia MIT. Todavia no hay una URL publica de repositorio para enlazar; cuando exista, se publicara desde esta pagina y desde la documentacion tecnica.</p>
+        <p>El codigo fuente se mantiene bajo licencia MIT en <a href="https://github.com/YavlPro/YavlGold" target="_blank" rel="noopener noreferrer">github.com/YavlPro/YavlGold</a>.</p>
       </section>
 
       <section class="trust-section">
@@ -71,6 +71,7 @@
         <a href="/#register" class="trust-button trust-button--primary">Comenzar Ahora</a>
         <a href="/" class="trust-button">Volver al inicio</a>
         <a href="/status" class="trust-button">Estado</a>
+        <a href="/security" class="trust-button">Seguridad</a>
         <a href="/anti-suplantacion" class="trust-button">Anti-suplantación</a>
       </div>
     </div>
@@ -88,6 +89,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/privacy.html
+++ b/apps/gold/privacy.html
@@ -111,6 +111,7 @@
         <a href="/#register" class="trust-button trust-button--primary">Comenzar Ahora</a>
         <a href="/" class="trust-button">Volver al inicio</a>
         <a href="/terms" class="trust-button">Términos</a>
+        <a href="/security" class="trust-button">Seguridad</a>
         <a href="/anti-suplantacion" class="trust-button">Anti-suplantación</a>
       </div>
     </div>
@@ -128,6 +129,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/public/llms.txt
+++ b/apps/gold/public/llms.txt
@@ -28,7 +28,7 @@ This file contains the current product, architecture and routing policy for `app
 - `/dashboard/` user dashboard
 - `/agro/` released module
 - `/academia/`, `/social/`, `/tecnologia/`, `/crypto/` unavailable placeholders
-- `/open-source`, `/anti-suplantacion`, `/privacy`, `/terms`, `/status` trust and operations pages
+- `/open-source`, `/security`, `/anti-suplantacion`, `/privacy`, `/terms`, `/status` trust and operations pages
 - `/health` public JSON health endpoint without secrets
 
 ## 4. Auth policy

--- a/apps/gold/public/sitemap.xml
+++ b/apps/gold/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://yavlgold.com/security</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://yavlgold.com/privacy</loc>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>

--- a/apps/gold/security.html
+++ b/apps/gold/security.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="es">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Seguridad - YavlGold</title>
+  <meta name="description" content="Politica operativa de seguridad y reporte privado de vulnerabilidades de YavlGold Agro V1.">
+  <link rel="icon" type="image/webp" href="/brand/logo.webp">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@700;900&family=Rajdhani:wght@400;600;700&family=Playfair+Display:ital,wght@0,400;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+    integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+    crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="/assets/css/trust-pages.css">
+</head>
+
+<body class="trust-page">
+  <a href="#main-content" class="trust-skip-link">Saltar al contenido principal</a>
+
+  <header class="trust-header">
+    <div class="trust-header__inner">
+      <a href="/" class="trust-header__brand" aria-label="Volver a YavlGold">
+        <img src="/brand/logo.webp" alt="YavlGold" width="32" height="32">
+        <span class="trust-header__title">YavlGold</span>
+      </a>
+      <span class="trust-header__badge">Seguridad</span>
+      <nav class="trust-header__nav" aria-label="Enlaces principales">
+        <a href="/" class="trust-header__link"><i class="fas fa-arrow-left" aria-hidden="true"></i> <span>Inicio</span></a>
+        <a href="/docs-agro" class="trust-header__link"><i class="fas fa-book" aria-hidden="true"></i> <span>Documentacion</span></a>
+        <a href="/#register" class="trust-header__link trust-header__link--cta">Comenzar Ahora</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content" class="trust-shell">
+    <span class="trust-kicker">Seguridad</span>
+    <h1 class="trust-title">Reporte privado de vulnerabilidades</h1>
+    <p class="trust-lead">Esta pagina resume el canal operativo para reportar vulnerabilidades de YavlGold Agro V1. No sustituye revision legal, auditoria externa ni certificacion de cumplimiento.</p>
+
+    <div class="trust-panel">
+      <section class="trust-section">
+        <h2>Canal de reporte</h2>
+        <p>No abras issues publicos para reportar vulnerabilidades.</p>
+        <div class="trust-meta-grid">
+          <div class="trust-meta">
+            <span>Email privado</span>
+            <strong><a href="mailto:soporte@yavlgold.com?subject=Seguridad%20YavlGold">soporte@yavlgold.com</a></strong>
+          </div>
+          <div class="trust-meta">
+            <span>Asunto sugerido</span>
+            <strong>Seguridad</strong>
+          </div>
+          <div class="trust-meta">
+            <span>Repositorio</span>
+            <strong><a href="https://github.com/YavlPro/YavlGold" target="_blank" rel="noopener noreferrer">github.com/YavlPro/YavlGold</a></strong>
+          </div>
+          <div class="trust-meta">
+            <span>Security policy</span>
+            <strong><a href="https://github.com/YavlPro/YavlGold/security/policy" target="_blank" rel="noopener noreferrer">GitHub Security Policy</a></strong>
+          </div>
+        </div>
+      </section>
+
+      <section class="trust-section">
+        <h2>Alcance</h2>
+        <ul>
+          <li>YavlGold Agro V1 y sus paginas publicas.</li>
+          <li>Supabase Auth, RLS, Storage policies y Edge Functions.</li>
+          <li>Configuracion de despliegue en Vercel y endpoint /health.</li>
+          <li>Separacion de datos por usuario y controles anti cross-user.</li>
+        </ul>
+      </section>
+
+      <section class="trust-section">
+        <h2>Fuera de alcance</h2>
+        <ul>
+          <li>Denegacion de servicio, spam, scraping masivo o pruebas destructivas.</li>
+          <li>Ingenieria social, ataques fisicos o intento de acceder a cuentas de terceros.</li>
+          <li>Reportes sin impacto tecnico reproducible.</li>
+        </ul>
+      </section>
+
+      <section class="trust-section">
+        <h2>Objetivos de respuesta</h2>
+        <p>Estos tiempos son objetivos operativos, no garantias legales.</p>
+        <ul>
+          <li>Acuse de recibo: 72 horas.</li>
+          <li>Primera triage: 7 dias.</li>
+          <li>Mitigacion: segun severidad, explotabilidad y alcance.</li>
+        </ul>
+      </section>
+
+      <section class="trust-section">
+        <h2>Buenas practicas para reportar</h2>
+        <ul>
+          <li>Incluye ruta, modulo, tabla, bucket o funcion afectada.</li>
+          <li>Agrega pasos de reproduccion y resultado esperado.</li>
+          <li>Elimina llaves, tokens, contrasenas, datos de usuarios o capturas sensibles.</li>
+          <li>Indica si el impacto involucra datos cross-user, auth, storage o privacidad.</li>
+        </ul>
+      </section>
+
+      <div class="trust-actions">
+        <a href="mailto:soporte@yavlgold.com?subject=Seguridad%20YavlGold" class="trust-button trust-button--primary">Reportar seguridad</a>
+        <a href="/open-source" class="trust-button">Open Source</a>
+        <a href="/status" class="trust-button">Estado</a>
+        <a href="/anti-suplantacion" class="trust-button">Anti-suplantacion</a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="trust-footer">
+    <div class="trust-footer__inner">
+      <div class="trust-footer__brand">
+        <img src="/brand/logo.webp" alt="YavlGold" width="24" height="24">
+        <span>YavlGold</span>
+      </div>
+      <nav class="trust-footer__links" aria-label="Enlaces del pie de pagina">
+        <a href="/">Inicio</a>
+        <a href="/agro/">Agro</a>
+        <a href="/docs-agro">Documentacion</a>
+        <a href="/open-source">Licencia MIT</a>
+        <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
+        <a href="/faq">Preguntas frecuentes</a>
+        <a href="/soporte">Soporte</a>
+        <a href="/terms">Terminos</a>
+        <a href="/privacy">Privacidad</a>
+      </nav>
+      <p class="trust-footer__copy">&copy; 2026 YavlGold. Tu finca digital.</p>
+    </div>
+  </footer>
+</body>
+
+</html>

--- a/apps/gold/sitemap.xml
+++ b/apps/gold/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://yavlgold.com/security</loc>
+    <lastmod>2026-04-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://yavlgold.com/privacy</loc>
     <lastmod>2026-04-20</lastmod>
     <changefreq>monthly</changefreq>

--- a/apps/gold/soporte.html
+++ b/apps/gold/soporte.html
@@ -88,6 +88,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/status.html
+++ b/apps/gold/status.html
@@ -88,6 +88,7 @@
         <a href="/" class="trust-button">Volver al inicio</a>
         <a href="/health" class="trust-button">Health JSON</a>
         <a href="/open-source" class="trust-button">Open Source</a>
+        <a href="/security" class="trust-button">Seguridad</a>
       </div>
     </div>
   </main>
@@ -104,6 +105,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/terms.html
+++ b/apps/gold/terms.html
@@ -78,7 +78,7 @@
 
       <section class="trust-section">
         <h2>Datos, exportacion y borrado</h2>
-        <p>El usuario puede solicitar exportacion o eliminacion de datos por los canales definidos en la Politica de Privacidad. Los tiempos, alcance y excepciones estan pendientes de formalizacion operativa.</p>
+        <p>El usuario puede solicitar exportacion o eliminacion de datos por los canales definidos en la Politica de Privacidad. Como objetivo operativo, YavlGold acusa recibo en 72 horas y realiza primera revision en un maximo de 7 dias; el alcance final depende de seguridad, respaldo, obligaciones aplicables y revision legal cuando corresponda.</p>
       </section>
 
       <section class="trust-section">
@@ -101,6 +101,7 @@
         <a href="/#register" class="trust-button trust-button--primary">Comenzar Ahora</a>
         <a href="/" class="trust-button">Volver al inicio</a>
         <a href="/privacy" class="trust-button">Privacidad</a>
+        <a href="/security" class="trust-button">Seguridad</a>
         <a href="/anti-suplantacion" class="trust-button">Anti-suplantacion</a>
       </div>
     </div>
@@ -118,6 +119,8 @@
         <a href="/docs-agro">Documentacion</a>
         <a href="/open-source">Licencia MIT</a>
         <a href="/status">Estado</a>
+        <a href="/security">Seguridad</a>
+        <a href="/anti-suplantacion">Anti-suplantacion</a>
         <a href="/faq">Preguntas frecuentes</a>
         <a href="/soporte">Soporte</a>
         <a href="/terms">Terminos</a>

--- a/apps/gold/vite.config.js
+++ b/apps/gold/vite.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
         privacy: 'privacy.html',
         openSource: 'open-source.html',
         antiSuplantacion: 'anti-suplantacion.html',
+        security: 'security.html',
         status: 'status.html',
         docsAgro: 'docs-agro.html',
         dashboard: 'dashboard/index.html',


### PR DESCRIPTION
## Riesgo mitigado

Placeholders visibles y paginas trust sin ruta publica de seguridad.

## Cambios

- Reemplaza `ORG/REPO`, `SECURITY_EMAIL` y `[PENDIENTE]` visibles con datos reales u honestos.
- Agrega `apps/gold/security.html` al MPA y sitemap.
- Alinea enlaces de footer/nav hacia `/open-source`, `/security`, `/terms`, `/privacy` y `/anti-suplantacion`.
- Actualiza Open Source/anti-suplantacion con `https://github.com/YavlPro/YavlGold`.
- Rebasado sobre `origin/main` despues del merge de PR #84; `AGENT_REPORT_ACTIVE.md` queda igual que `main` para evitar conflictos documentales.

## Pruebas

- `rg -n "ORG/REPO|SECURITY_EMAIL|\[PENDIENTE\]" ...` sobre superficies visibles -> sin resultados.
- `pnpm build:gold` -> OK.
- `git diff --check` -> OK.
- `git merge-tree --write-tree origin/main codex/2026-04-23-prB-placeholders-trust` -> OK.