### PR TITLE
PR D: Verify health and status contract

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -7,17 +7,11 @@ module.exports = function handler(req, res) {
   res.setHeader('Cache-Control', 'no-store, max-age=0');
   res.setHeader('X-Content-Type-Options', 'nosniff');
 
-  const commit = process.env.VERCEL_GIT_COMMIT_SHA
-    ? process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 12)
-    : null;
-
   const payload = {
     ok: true,
     service: 'yavlgold-agro',
     version: '1.0.0',
-    timestamp: new Date().toISOString(),
-    environment: process.env.VERCEL_ENV || 'local',
-    commit
+    timestamp: new Date().toISOString()
   };
 
   if (req.method === 'HEAD') {

--- a/apps/gold/docs/ops/HEALTH_STATUS_VALIDATION_2026-04-23.md
+++ b/apps/gold/docs/ops/HEALTH_STATUS_VALIDATION_2026-04-23.md
@@ -1,0 +1,42 @@
+# Health / Status Validation — 2026-04-23
+
+Estado: validacion local del handler y revision estatica de pagina publica.
+
+## Entorno
+
+- Repo: `C:\Users\yerik\gold`
+- Rama: `codex/2026-04-23-prD-health-status-verify`
+- Validacion: handler local `api/health.js` invocado con mock de request/response.
+- Nota: no se consulto produccion Vercel en esta rama; la prueba local valida el contrato de codigo que Vercel ejecuta para `/health`.
+
+## Resultado `/health`
+
+| Metodo | Resultado esperado | Resultado observado |
+| --- | --- | --- |
+| GET | 200 JSON minimo | 200, body con `ok`, `service`, `version`, `timestamp` |
+| HEAD | 200 sin body | 200, `end()` sin body |
+| POST | 405 | 405, body `{ ok: false, error: "METHOD_NOT_ALLOWED" }` y header `Allow: GET, HEAD` |
+
+## Seguridad del payload
+
+- No devuelve `SUPABASE_*`, `JWT_SECRET`, `PRIVATE_KEY`, service role ni tokens.
+- No devuelve stack traces, usuario, cuenta, tablas, buckets ni datos de sesion.
+- Se retiro `environment` y `commit` del payload para evitar exponer valores derivados de variables de entorno.
+
+## Resultado `/status`
+
+- `apps/gold/status.html` es una pagina publica estatica con `trust-pages.css`.
+- No carga `auth-guard`, `session-guard`, `AuthClient`, Supabase SDK ni scripts de login.
+- El CTA `Comenzar Ahora` apunta a `/#register`, que conserva el flujo real de registro en landing.
+
+## Comandos ejecutados
+
+```bash
+node -e "const h=require('./api/health.js'); async function run(m){let out={method:m,headers:{},statusCode:null,body:null,ended:false}; const res={setHeader:(k,v)=>out.headers[k]=v,status:(c)=>{out.statusCode=c;return res;},json:(b)=>{out.body=b;return out;},end:()=>{out.ended=true;return out;}}; h({method:m},res); return out;} Promise.all(['GET','HEAD','POST'].map(run)).then(r=>console.log(JSON.stringify(r.map(x=>({method:x.method,statusCode:x.statusCode,hasBody:!!x.body,ended:x.ended,bodyKeys:x.body?Object.keys(x.body):[]})),null,2)));"
+rg -n "auth-guard|session-guard|login|register|AuthClient|supabase" apps/gold/status.html
+rg -n "process\.env|SUPABASE|KEY|SECRET|TOKEN|service_role|JWT" api/health.js
+```
+
+## Pendientes
+
+- Validar `GET /health`, `HEAD /health`, `POST /health` contra el despliegue Vercel una vez publicada la rama.


### PR DESCRIPTION
## Riesgo mitigado

`/health` exponiendo payload mayor al necesario o metodos no controlados.

## Cambios

- Reduce `api/health.js` a JSON minimo: `ok`, `service`, `version`, `timestamp`.
- Conserva GET/HEAD 200 y POST 405 con `Allow: GET, HEAD`.
- Documenta evidencia en `apps/gold/docs/ops/HEALTH_STATUS_VALIDATION_2026-04-23.md`.
- Verifica que `/status` sea pagina publica estatica sin auth guard ni Supabase client.
- Rebasado sobre `origin/main` despues del merge de PR #84; `AGENT_REPORT_ACTIVE.md` queda igual que `main` para evitar conflictos documentales.

## Pruebas

- Handler local GET -> 200 JSON minimo.
- Handler local HEAD -> 200 sin body.
- Handler local POST -> 405.
- `rg` en `api/health.js` para env/keys/secrets -> sin resultados.
- `pnpm build:gold` -> OK.
- `git diff --check` -> OK.
- `git merge-tree --write-tree origin/main codex/2026-04-23-prD-health-status-verify` -> OK.