### PR TITLE
docs: add post-merge rollout verification

### DIFF
--- a/apps/gold/docs/AGENT_REPORT_ACTIVE.md
+++ b/apps/gold/docs/AGENT_REPORT_ACTIVE.md
@@ -2678,6 +2678,28 @@ Corregir la posicion del logo del proyecto dentro del footer de la landing page.
 
 ---
 
+## Sesion 2026-04-23 — Verificacion post-merge rollout
+
+### Resultado
+
+- `main` actualizado a `4a9a1e8`; contiene merges #82, #83, #84 y #85.
+- Repo limpio, sin `::git-` en archivos versionados.
+- Placeholders visibles en paginas publicas: PASS.
+- Secret scan runtime: PASS; no `service_role` ni `SUPABASE_SERVICE_ROLE` en `apps/gold/dist`, `api`, `apps/gold/assets` ni `apps/gold/agro`.
+- `pnpm build:gold`: PASS con warning esperado por Node local `v25.6.0` frente a engine Node 20.x.
+- Health/status local y deploy publico: PASS.
+- Supabase RLS/Storage A/B real: BLOQUEADO/FAIL operativo; Docker daemon no disponible, dry-run remoto queda en timeout, no hay env QA A/B local.
+
+### Evidencia creada
+
+| Archivo | Rol |
+|---|---|
+| `apps/gold/docs/ops/POST_MERGE_ROLLOUT_VERIFICATION_2026-04-23.md` | Repo, build, secret scan, placeholders, deploy y ramas locales ahead. |
+| `apps/gold/docs/ops/POST_MERGE_HEALTH_STATUS_VERIFICATION_2026-04-23.md` | Contrato local/deploy de `/health` y `/status`. |
+| `apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md` | Estado BLOQUEADO/FAIL de prueba A/B real y runbook exacto. |
+
+---
+
 ## Sesion 2026-04-23 — PR C Node 20
 
 ### Diagnostico breve

--- a/apps/gold/docs/ops/POST_MERGE_HEALTH_STATUS_VERIFICATION_2026-04-23.md
+++ b/apps/gold/docs/ops/POST_MERGE_HEALTH_STATUS_VERIFICATION_2026-04-23.md
@@ -1,0 +1,76 @@
+# Post-Merge Health / Status Verification — 2026-04-23
+
+Estado: PASS local y PASS en deploy publico.
+
+> Nota de fecha: archivo solicitado con etiqueta `2026-04-23`; ejecucion real posterior al merge de PRs el 2026-04-24 temprano.
+
+## Local handler
+
+Comando:
+
+```bash
+node -e "const h=require('./api/health.js'); async function run(m){let out={method:m,headers:{},statusCode:null,body:null,ended:false}; const res={setHeader:(k,v)=>out.headers[k]=v,status:(c)=>{out.statusCode=c;return res;},json:(b)=>{out.body=b;return out;},end:()=>{out.ended=true;return out;}}; h({method:m},res); return out;} Promise.all(['GET','HEAD','POST'].map(run)).then(r=>console.log(JSON.stringify(r.map(x=>({method:x.method,statusCode:x.statusCode,hasBody:!!x.body,ended:x.ended,bodyKeys:x.body?Object.keys(x.body):[]})),null,2)));"
+```
+
+Resultado:
+
+| Metodo | Resultado |
+| --- | --- |
+| GET | PASS: 200 con body JSON |
+| HEAD | PASS: 200 sin body |
+| POST | PASS: 405 |
+
+Body keys observadas en GET:
+
+```text
+ok, service, version, timestamp
+```
+
+No se devuelve `environment`, commit SHA, env vars, stack trace, usuario, tablas, buckets ni datos de sesion.
+
+## Codigo
+
+`api/health.js` responde:
+
+- `GET` y `HEAD`;
+- `405 METHOD_NOT_ALLOWED` para otros metodos;
+- `Cache-Control: no-store, max-age=0`;
+- `X-Content-Type-Options: nosniff`;
+- JSON minimo con `ok`, `service`, `version`, `timestamp`.
+
+## `/status` local
+
+Comando:
+
+```bash
+rg -n "auth-guard|session-guard|AuthClient|createClient|supabase-js|SUPABASE|VITE_SUPABASE|login|register" apps/gold/status.html
+```
+
+Resultado:
+
+- PASS: solo aparecen enlaces a `/#register`.
+- No inicializa Supabase client.
+- No carga `auth-guard`, `session-guard`, `AuthClient` ni `supabase-js`.
+- Es pagina publica estatica con `trust-pages.css`.
+
+## Deploy publico
+
+Comandos:
+
+```bash
+curl -iL https://yavlgold.com/health
+curl -IL https://yavlgold.com/health
+curl -iL -X POST https://yavlgold.com/health
+curl -iL https://yavlgold.com/status
+```
+
+Resultados:
+
+| Ruta | Resultado |
+| --- | --- |
+| `GET /health` | PASS: `https://yavlgold.com` redirige 307 a `https://www.yavlgold.com/health`; destino responde 200 JSON minimo |
+| `HEAD /health` | PASS: 307 -> 200 sin body |
+| `POST /health` | PASS: 307 -> 405 con `Allow: GET, HEAD` |
+| `GET /status` | PASS: 307 -> 200 `text/html; charset=utf-8` |
+
+El redirect canonico a `www.yavlgold.com` no rompe el contrato final.

--- a/apps/gold/docs/ops/POST_MERGE_ROLLOUT_VERIFICATION_2026-04-23.md
+++ b/apps/gold/docs/ops/POST_MERGE_ROLLOUT_VERIFICATION_2026-04-23.md
@@ -1,0 +1,73 @@
+# Post-Merge Rollout Verification — 2026-04-23
+
+Estado: verificacion post-merge ejecutada sobre `main`.
+
+> Nota de fecha: el identificador de rollout solicitado es `2026-04-23`; la ejecucion local ocurrio el 2026-04-24 UTC/Caracas temprano, despues de que los PRs #82, #83, #84 y #85 ya estaban mergeados en `main`.
+
+## Repo
+
+| Check | Resultado | Evidencia |
+| --- | --- | --- |
+| `git checkout main` + `git pull --ff-only` | PASS | `main` fast-forward a `4a9a1e8` |
+| PRs rollout en `main` | PASS | Log incluye merges #82, #83, #84, #85 |
+| Working tree limpio al inicio | PASS | `git status --short --branch` sin cambios |
+| Basura de agente `::git-` | PASS | `rg -n "::git-" . --glob '!**/node_modules/**' --glob '!**/dist/**'` sin resultados |
+
+## Secret scan
+
+Comandos ejecutados sin imprimir valores de secretos:
+
+```bash
+rg -n -o "service_role|SUPABASE_SERVICE_ROLE" . --glob '!**/node_modules/**' --glob '!**/dist/**' --glob '!**/.git/**' --glob '!**/.env*'
+rg -n -o "JWT_SECRET|PRIVATE_KEY|SUPABASE_.*KEY|anon_key" . --glob '!**/node_modules/**' --glob '!**/dist/**' --glob '!**/.git/**' --glob '!**/.env*'
+rg -n -o "service_role|SUPABASE_SERVICE_ROLE" apps/gold/dist api apps/gold/assets apps/gold/agro --glob '!**/*.md'
+```
+
+Resultado:
+
+- PASS para frontend/dist/API/Agro: no aparece `service_role` ni `SUPABASE_SERVICE_ROLE` en superficies runtime revisadas.
+- PASS para tokens reales: detector adicional de JWT/private keys/Supabase tokens no encontro secretos reales.
+- Coincidencias restantes son nombres de variables, documentacion, SQL grants al rol `service_role`, o uso de `VITE_SUPABASE_ANON_KEY` via `import.meta.env`.
+
+## Placeholders publicos
+
+Comando:
+
+```bash
+rg -n "\[PENDIENTE\]|ORG/REPO|DOMINIO|SECURITY_EMAIL" apps/gold --glob "*.html" --glob "public/*.txt" --glob "*.xml" --glob "!dist/**"
+```
+
+Resultado: PASS. No hay placeholders visibles en paginas publicas, sitemap ni `llms.txt`.
+
+## Node / build
+
+| Check | Resultado |
+| --- | --- |
+| `pnpm -v` | `9.1.0` |
+| `node -v` | `v25.6.0` |
+| `.nvmrc` | `20` |
+| README requisitos Node 20 | PASS |
+| `pnpm build:gold` | PASS |
+| `git diff --check` | PASS |
+
+Nota: el warning de engine es esperado en esta maquina porque corre Node `v25.6.0`, pero el repo ya fija Node 20 en `.nvmrc` y `engines`.
+
+## Deploy publico
+
+Dominio probado: `https://yavlgold.com` con redirect a `https://www.yavlgold.com`.
+
+| Check | Resultado |
+| --- | --- |
+| `curl -iL https://yavlgold.com/health` | PASS: 307 -> 200 JSON minimo |
+| `curl -IL https://yavlgold.com/health` | PASS: 307 -> 200 sin body |
+| `curl -iL -X POST https://yavlgold.com/health` | PASS: 307 -> 405, `Allow: GET, HEAD` |
+| `curl -iL https://yavlgold.com/status` | PASS: 307 -> 200 HTML publico |
+
+## Ramas locales ajenas al rollout
+
+`git branch -vv` muestra dos ramas locales con commits no empujados que no pertenecen al rollout #82-#85:
+
+- `codex/fix-mobile-logout` — `ahead 1`
+- `codex/fix-section-stats-crop-sync` — `ahead 1`
+
+No se empujaron automaticamente por scope.

--- a/apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md
+++ b/apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md
@@ -1,0 +1,100 @@
+# Post-Merge RLS + Storage Verification — 2026-04-23
+
+Estado: BLOQUEADO / FAIL operativo para prueba A/B real.
+
+> No se afirma verificacion real de RLS/Storage. La prueba A/B no pudo ejecutarse contra DB viva por falta de Docker local y por ausencia de variables/usuarios QA configurados para el smoke test.
+
+## Entorno
+
+| Item | Resultado |
+| --- | --- |
+| Supabase CLI | `2.72.7` |
+| Proyecto enlazado | `gerzlzprkarikblqxpjt` (`YavlGold`) |
+| Docker daemon | FAIL: pipe `dockerDesktopLinuxEngine` no disponible |
+| `.env` local | No existe |
+| `testqacredentials.md` | Existe, pero no contiene `SUPABASE_URL`, `SUPABASE_ANON_KEY` ni usuarios A/B con los nombres requeridos por el script |
+
+## Intentos ejecutados
+
+```bash
+docker info --format '{{.ServerVersion}}'
+supabase --version
+supabase projects list
+supabase start --workdir .
+supabase db push --dry-run --workdir .
+node tools/rls-smoke-test.js
+```
+
+Resultados:
+
+| Prueba | Resultado |
+| --- | --- |
+| `docker info` | FAIL: no conecta a Docker Desktop daemon |
+| `supabase start --workdir .` | FAIL: Docker Desktop requerido |
+| `supabase db push --dry-run --workdir .` | BLOQUEADO: timeout en 45s; proceso detenido |
+| `node tools/rls-smoke-test.js` | FAIL esperado: faltan `SUPABASE_URL`, `SUPABASE_ANON_KEY` |
+
+## Cobertura esperada del script
+
+Archivo: `tools/rls-smoke-test.js`.
+
+Tabla por defecto:
+
+- `agro_pending`
+
+Bucket por defecto:
+
+- `agro-evidence`
+
+Casos cubiertos cuando hay entorno:
+
+| Caso | Resultado actual |
+| --- | --- |
+| Insert own row usuario A/B | NO EJECUTADO |
+| Select own row | NO EJECUTADO |
+| Select cross-user | NO EJECUTADO |
+| Update cross-user | NO EJECUTADO |
+| Delete cross-user | NO EJECUTADO |
+| Insert con `user_id` ajeno | NO EJECUTADO |
+| Storage upload en prefijo propio | NO EJECUTADO |
+| Storage upload en prefijo de otro usuario | NO EJECUTADO |
+| Storage download de objeto ajeno | NO EJECUTADO |
+
+## Razon del FAIL/BLOQUEADO
+
+- Local no disponible: Docker Desktop/daemon no esta corriendo.
+- Staging no identificado de forma segura: el CLI lista un proyecto enlazado `YavlGold`, pero no se confirma que sea staging. No se ejecuto `supabase db push` real contra un proyecto potencialmente productivo.
+- No hay `SUPABASE_URL`, `SUPABASE_ANON_KEY` ni credenciales QA A/B disponibles en env local con los nombres requeridos por el script.
+
+## Runbook exacto para cerrar PASS
+
+### Opcion local
+
+```bash
+supabase start --workdir .
+supabase db reset --workdir . --local --no-seed
+SUPABASE_URL=<local_url> SUPABASE_ANON_KEY=<local_anon> SUPABASE_USER_A_EMAIL=<qa-a> SUPABASE_USER_A_PASSWORD=<pwd-a> SUPABASE_USER_B_EMAIL=<qa-b> SUPABASE_USER_B_PASSWORD=<pwd-b> node tools/rls-smoke-test.js
+```
+
+### Opcion staging
+
+```bash
+supabase login
+supabase link --project-ref <PROJECT_REF_STAGING>
+supabase db push
+SUPABASE_URL=<staging_url> SUPABASE_ANON_KEY=<staging_anon> SUPABASE_USER_A_EMAIL=<qa-a> SUPABASE_USER_A_PASSWORD=<pwd-a> SUPABASE_USER_B_EMAIL=<qa-b> SUPABASE_USER_B_PASSWORD=<pwd-b> node tools/rls-smoke-test.js
+```
+
+El resultado aceptable debe ser JSON `ok: true` con:
+
+- `db_select_cross_user: blocked`
+- `db_update_cross_user: blocked`
+- `db_delete_cross_user: blocked`
+- `db_insert_wrong_user_id: blocked`
+- `storage_upload_cross_prefix: blocked`
+- `storage_read_cross_prefix: blocked`
+
+## TODO externo
+
+- Confirmar project-ref de staging o autorizar explicitamente el proyecto enlazado para pruebas.
+- Proveer variables QA A/B o iniciar Docker Desktop local.


### PR DESCRIPTION
## Riesgo mitigado

Falta de evidencia post-merge consolidada para repo/build/secret scans, health/status, deploy y estado real de RLS/Storage.

## Cambios

- Agrega `apps/gold/docs/ops/POST_MERGE_ROLLOUT_VERIFICATION_2026-04-23.md`.
- Agrega `apps/gold/docs/ops/POST_MERGE_HEALTH_STATUS_VERIFICATION_2026-04-23.md`.
- Agrega `apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md`.
- Actualiza `apps/gold/docs/AGENT_REPORT_ACTIVE.md` con resumen operativo.

## Pruebas

- `git checkout main && git pull --ff-only` -> main actualizado a `4a9a1e8`.
- `rg -n "::git-" ...` -> sin resultados.
- Placeholder scan en HTML/sitemap/llms -> sin resultados.
- Secret scans sin imprimir valores -> no hay tokens reales; runtime frontend/dist/API sin `service_role`.
- `node` health handler local -> GET 200, HEAD 200, POST 405.
- `curl -iL https://yavlgold.com/health` -> 307 -> 200 JSON minimo.
- `curl -iL -X POST https://yavlgold.com/health` -> 307 -> 405.
- `curl -iL https://yavlgold.com/status` -> 307 -> 200 HTML publico.
- `git diff --check` -> OK.
- `pnpm build:gold` -> OK.

## Nota critica

RLS/Storage A/B real queda BLOQUEADO/FAIL operativo: Docker daemon no disponible, no hay `.env` con Supabase URL/anon, el archivo QA local no contiene las variables requeridas, y no se aplico `db push` sobre el proyecto enlazado porque no esta confirmado como staging.