### PR TITLE
docs: record staging RLS/storage A/B verification

### DIFF
--- a/apps/gold/docs/AGENT_REPORT_ACTIVE.md
+++ b/apps/gold/docs/AGENT_REPORT_ACTIVE.md
@@ -2718,3 +2718,24 @@ Corregir la posicion del logo del proyecto dentro del footer de la landing page.
 ### Verificacion pendiente de esta rama
 
 - Ejecutar `pnpm build:gold`.
+
+---
+
+## Sesion 2026-04-24 — Verificacion Supabase RLS/Storage post-merge
+
+### Resultado
+
+- DB RLS: BLOQUEADO.
+- Storage: BLOQUEADO.
+- `main` fue actualizado por fast-forward hasta `0972003`.
+- `tools/rls-smoke-test.js` existe.
+- `supabase login` OK.
+- `supabase projects list` solo mostro `YavlGold` / `gerzlzprkarikblqxpjt`; el nombre no confirma staging/dev.
+- No se ejecuto `supabase link`, `supabase db push --dry-run` ni `supabase db push` porque no hay staging confirmado.
+- `node tools/rls-smoke-test.js` fallo antes de autenticar por ausencia de `SUPABASE_URL` y `SUPABASE_ANON_KEY`.
+
+### Evidencia actualizada
+
+| Archivo | Rol |
+|---|---|
+| `apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md` | Bloqueo remoto documentado con project ref listado, metodo de confirmacion staging, dry-run no ejecutado por seguridad y runbook exacto. |

--- a/apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md
+++ b/apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md
@@ -1,8 +1,73 @@
 # Post-Merge RLS + Storage Verification — 2026-04-23
 
-Estado: BLOQUEADO / FAIL operativo para prueba A/B real.
+Estado: BLOQUEADO para DB RLS y BLOQUEADO para Storage.
 
 > No se afirma verificacion real de RLS/Storage. La prueba A/B no pudo ejecutarse contra DB viva por falta de Docker local y por ausencia de variables/usuarios QA configurados para el smoke test.
+>
+> Actualizacion 2026-04-24: tampoco se aplicaron migraciones ni se ejecuto `supabase db push --dry-run` remoto porque `supabase projects list` no mostro un proyecto cuyo nombre confirme staging/dev.
+
+## Actualizacion 2026-04-24 - verificacion remota staging
+
+| Item | Resultado |
+| --- | --- |
+| Fecha/hora local | `2026-04-24 09:54:22 -04:00` |
+| HEAD verificado | `0972003` (`Merge pull request #86 from YavlPro/codex/2026-04-23-post-merge-verification`) |
+| Supabase CLI | `2.72.7` |
+| Project ref usado para `link`/`db push` | Ninguno. No se confirmo staging. |
+| Proyecto listado/enlazado | `YavlGold` / `gerzlzprkarikblqxpjt` |
+| Metodo de confirmacion de staging | `supabase projects list`; criterio obligatorio: nombre del proyecto debe indicar claramente `staging` o `dev`. |
+| Resultado de confirmacion | BLOQUEADO: solo aparece `YavlGold`, sin indicador staging/dev. |
+| `supabase db push --dry-run` | NO EJECUTADO: bloqueado por falta de staging confirmado. |
+| `supabase db push` | NO EJECUTADO: prohibido aplicar migraciones sin staging confirmado. |
+| Smoke test A/B | BLOQUEADO: `node tools/rls-smoke-test.js` falla antes de autenticar por ausencia de `SUPABASE_URL` y `SUPABASE_ANON_KEY`. |
+
+### Comandos ejecutados el 2026-04-24
+
+```bash
+git checkout main
+git pull --ff-only
+supabase --version
+supabase login
+supabase projects list
+node tools/rls-smoke-test.js
+```
+
+### Resumen seguro de `supabase projects list`
+
+No se pega la salida completa. Resultado relevante:
+
+| Nombre | Ref | Lectura operativa |
+| --- | --- | --- |
+| `YavlGold` | `gerzlzprkarikblqxpjt` | No confirma staging/dev; tratado como no apto para `db push`. |
+
+### Resultado A/B 2026-04-24
+
+| Superficie | Caso | Resultado |
+| --- | --- | --- |
+| DB RLS | A no puede leer filas de B | BLOQUEADO / NO EJECUTADO |
+| DB RLS | A no puede update de B | BLOQUEADO / NO EJECUTADO |
+| DB RLS | A no puede delete de B | BLOQUEADO / NO EJECUTADO |
+| DB RLS | A no puede insert con `user_id != auth.uid()` | BLOQUEADO / NO EJECUTADO |
+| Storage | A puede subir/leer en su carpeta | BLOQUEADO / NO EJECUTADO |
+| Storage | A no puede subir en carpeta de B | BLOQUEADO / NO EJECUTADO |
+| Storage | A no puede leer objeto de B | BLOQUEADO / NO EJECUTADO |
+
+Salida segura del smoke test:
+
+```text
+Missing required env: SUPABASE_URL, SUPABASE_ANON_KEY
+```
+
+### Runbook exacto para desbloquear remoto
+
+1. Crear o identificar un proyecto Supabase cuyo nombre visible indique `staging` o `dev`.
+2. Repetir `supabase projects list` y registrar solo nombre + ref del proyecto staging/dev.
+3. Ejecutar `supabase link --project-ref <STAGING_PROJECT_REF>`.
+4. Ejecutar `supabase db push --dry-run`.
+5. Si el dry-run muestra solo migraciones/policies esperadas de RLS/Storage, ejecutar `supabase db push`.
+6. Exportar localmente las variables `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_USER_A_EMAIL`, `SUPABASE_USER_A_PASSWORD`, `SUPABASE_USER_B_EMAIL`, `SUPABASE_USER_B_PASSWORD`.
+7. Ejecutar `node tools/rls-smoke-test.js`.
+8. Registrar tabla PASS/FAIL por caso sin imprimir secretos.
 
 ## Entorno
 


### PR DESCRIPTION
## Summary
- Document Supabase RLS/Storage verification as blocked because no staging/dev project is visible in `supabase projects list`.
- Record that `db push --dry-run` and `db push` were not executed without confirmed staging.
- Record smoke test output with missing local env and runbook to unblock.

## Verification
- `supabase login`
- `supabase projects list` (only `YavlGold` / `gerzlzprkarikblqxpjt`, not staging/dev)
- `node tools/rls-smoke-test.js` (blocked: missing `SUPABASE_URL`, `SUPABASE_ANON_KEY`)
- `pnpm build:gold` (PASS; Node 25 vs engine 20 warning)