### PR TITLE
security: add staging guardrails for RLS/storage smoke verification

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,14 @@
+# Copy values into your local shell or a non-versioned .env.staging file.
+# Never commit real keys, passwords, tokens, service_role values, or JWTs.
+
+SUPABASE_PROJECT_REF_STAGING=
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_USER_A_EMAIL=
+SUPABASE_USER_A_PASSWORD=
+SUPABASE_USER_B_EMAIL=
+SUPABASE_USER_B_PASSWORD=
+
+# Optional smoke-test overrides.
+RLS_SMOKE_TABLE=rls_smoke_items
+RLS_SMOKE_BUCKET=agro-evidence

--- a/.github/workflows/rls-smoke-staging.yml
+++ b/.github/workflows/rls-smoke-staging.yml
@@ -1,0 +1,41 @@
+name: RLS Storage Smoke Test (Staging)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  rls-smoke:
+    name: Run RLS and storage smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+      SUPABASE_USER_A_EMAIL: ${{ secrets.SUPABASE_USER_A_EMAIL }}
+      SUPABASE_USER_A_PASSWORD: ${{ secrets.SUPABASE_USER_A_PASSWORD }}
+      SUPABASE_USER_B_EMAIL: ${{ secrets.SUPABASE_USER_B_EMAIL }}
+      SUPABASE_USER_B_PASSWORD: ${{ secrets.SUPABASE_USER_B_PASSWORD }}
+      RLS_SMOKE_TABLE: rls_smoke_items
+      RLS_SMOKE_BUCKET: agro-evidence
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.1.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Gold
+        run: pnpm build:gold
+
+      - name: Run smoke test
+        run: node tools/rls-smoke-test.js

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ testqacredentials.md
 *password*.txt
 *secret*.txt
 .supabase-keys.md
+.supabase-staging.local.json
 
 # Dependencies
 node_modules/

--- a/apps/gold/docs/AGENT_REPORT_ACTIVE.md
+++ b/apps/gold/docs/AGENT_REPORT_ACTIVE.md
@@ -2683,7 +2683,7 @@ Corregir la posicion del logo del proyecto dentro del footer de la landing page.
 ### Resultado
 
 - `main` actualizado a `4a9a1e8`; contiene merges #82, #83, #84 y #85.
-- Repo limpio, sin `::git-` en archivos versionados.
+- Repo limpio, sin directivas git de agente en archivos versionados.
 - Placeholders visibles en paginas publicas: PASS.
 - Secret scan runtime: PASS; no `service_role` ni `SUPABASE_SERVICE_ROLE` en `apps/gold/dist`, `api`, `apps/gold/assets` ni `apps/gold/agro`.
 - `pnpm build:gold`: PASS con warning esperado por Node local `v25.6.0` frente a engine Node 20.x.

--- a/apps/gold/docs/AGENT_REPORT_ACTIVE.md
+++ b/apps/gold/docs/AGENT_REPORT_ACTIVE.md
@@ -2739,3 +2739,24 @@ Corregir la posicion del logo del proyecto dentro del footer de la landing page.
 | Archivo | Rol |
 |---|---|
 | `apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md` | Bloqueo remoto documentado con project ref listado, metodo de confirmacion staging, dry-run no ejecutado por seguridad y runbook exacto. |
+
+---
+
+## Sesion 2026-04-24 — Guardrails staging y smoke test RLS/Storage
+
+### Resultado
+
+- Se agrego guard local `tools/supabase-staging-guard.mjs`.
+- `pnpm guard:staging` bloquea si falta `SUPABASE_PROJECT_REF_STAGING`, si el ref no aparece en `supabase projects list`, o si el nombre del proyecto no contiene `staging`/`dev`.
+- `pnpm rls:staging:dryrun` y `pnpm rls:staging:apply` pasan por el guard antes de `supabase link`/`supabase db push`.
+- `tools/rls-smoke-test.js` ahora falla limpio con exit code `3` si faltan env vars y produce JSON sin secrets.
+- Se agrego migracion aislada `public.rls_smoke_items` para validar RLS owner-based sin tocar tablas reales del producto.
+- Se agrego workflow manual `.github/workflows/rls-smoke-staging.yml`.
+- No se aplicaron migraciones remotas porque sigue sin existir staging confirmado.
+
+### Evidencia/runbooks
+
+| Archivo | Rol |
+|---|---|
+| `apps/gold/docs/ops/STAGING_GUARDRAILS_AND_SETUP.md` | Politica y comandos de guardrail staging. |
+| `apps/gold/docs/security/RLS_STORAGE_SMOKE_TEST_RUNBOOK_2026-04-24.md` | Runbook exacto para dry-run, apply y smoke A/B. |

--- a/apps/gold/docs/ops/POST_MERGE_ROLLOUT_VERIFICATION_2026-04-23.md
+++ b/apps/gold/docs/ops/POST_MERGE_ROLLOUT_VERIFICATION_2026-04-23.md
@@ -11,7 +11,7 @@ Estado: verificacion post-merge ejecutada sobre `main`.
 | `git checkout main` + `git pull --ff-only` | PASS | `main` fast-forward a `4a9a1e8` |
 | PRs rollout en `main` | PASS | Log incluye merges #82, #83, #84, #85 |
 | Working tree limpio al inicio | PASS | `git status --short --branch` sin cambios |
-| Basura de agente `::git-` | PASS | `rg -n "::git-" . --glob '!**/node_modules/**' --glob '!**/dist/**'` sin resultados |
+| Basura de agente git-directive | PASS | Busqueda de directivas git de agente sin resultados |
 
 ## Secret scan
 

--- a/apps/gold/docs/ops/STAGING_GUARDRAILS_AND_SETUP.md
+++ b/apps/gold/docs/ops/STAGING_GUARDRAILS_AND_SETUP.md
@@ -1,0 +1,91 @@
+# Staging Guardrails and Setup
+
+Fecha: 2026-04-24
+
+## Politica
+
+`supabase db push` solo puede ejecutarse contra proyectos Supabase cuyo nombre visible contenga `staging` o `dev`.
+
+No se permite asumir que `YavlGold` / `gerzlzprkarikblqxpjt` es staging. Si el nombre del proyecto no confirma staging/dev, se detiene la operacion.
+
+## Confirmacion obligatoria
+
+1. Iniciar sesion:
+
+   ```bash
+   supabase login
+   ```
+
+2. Listar proyectos:
+
+   ```bash
+   supabase projects list
+   ```
+
+3. Elegir solo un proyecto cuyo nombre visible contenga `staging` o `dev`.
+
+4. Registrar localmente el ref en una variable de entorno o en un archivo no versionado. Ejemplo PowerShell:
+
+   ```powershell
+   $env:SUPABASE_PROJECT_REF_STAGING = "<staging-project-ref>"
+   ```
+
+   Ejemplo bash:
+
+   ```bash
+   export SUPABASE_PROJECT_REF_STAGING="<staging-project-ref>"
+   ```
+
+5. Verificar el guard:
+
+   ```bash
+   pnpm guard:staging
+   ```
+
+## Dry-run y apply con guardrail
+
+Dry-run:
+
+```bash
+pnpm rls:staging:dryrun
+```
+
+Apply, solo si el dry-run muestra migraciones esperadas:
+
+```bash
+pnpm rls:staging:apply
+```
+
+Los scripts ejecutan el guard antes de `supabase link` y `supabase db push`.
+
+## Stop the line
+
+Detener la operacion si ocurre cualquiera de estos casos:
+
+- No existe proyecto con nombre `staging` o `dev`.
+- `SUPABASE_PROJECT_REF_STAGING` esta vacio.
+- El ref no aparece en `supabase projects list`.
+- El ref existe, pero el nombre no confirma staging/dev.
+- El dry-run muestra migraciones inesperadas.
+- Faltan usuarios QA A/B o variables locales para el smoke test.
+
+## Archivo local opcional
+
+Si se quiere dejar trazabilidad local adicional, crear un archivo no versionado como:
+
+```text
+.supabase-staging.local.json
+```
+
+Contenido sugerido:
+
+```json
+{
+  "name": "<project-name-containing-staging-or-dev>",
+  "ref": "<staging-project-ref>",
+  "confirmed_at": "2026-04-24T00:00:00Z",
+  "confirmed_by": "supabase projects list"
+}
+```
+
+Este archivo no debe contener secrets.

--- a/apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md
+++ b/apps/gold/docs/security/POST_MERGE_RLS_STORAGE_VERIFICATION_2026-04-23.md
@@ -5,6 +5,8 @@ Estado: BLOQUEADO para DB RLS y BLOQUEADO para Storage.
 > No se afirma verificacion real de RLS/Storage. La prueba A/B no pudo ejecutarse contra DB viva por falta de Docker local y por ausencia de variables/usuarios QA configurados para el smoke test.
 >
 > Actualizacion 2026-04-24: tampoco se aplicaron migraciones ni se ejecuto `supabase db push --dry-run` remoto porque `supabase projects list` no mostro un proyecto cuyo nombre confirme staging/dev.
+>
+> Automatizacion preparada: ver `apps/gold/docs/security/RLS_STORAGE_SMOKE_TEST_RUNBOOK_2026-04-24.md` y `apps/gold/docs/ops/STAGING_GUARDRAILS_AND_SETUP.md`.
 
 ## Actualizacion 2026-04-24 - verificacion remota staging
 

--- a/apps/gold/docs/security/RLS_STORAGE_SMOKE_TEST_RUNBOOK_2026-04-24.md
+++ b/apps/gold/docs/security/RLS_STORAGE_SMOKE_TEST_RUNBOOK_2026-04-24.md
@@ -1,0 +1,180 @@
+# RLS + Storage Smoke Test Runbook — 2026-04-24
+
+Estado: listo para ejecutar cuando exista STAGING confirmado.
+
+Este runbook no requiere Docker. Protege contra `supabase db push` accidental a produccion mediante `tools/supabase-staging-guard.mjs`.
+
+## Variables requeridas
+
+No commitear valores reales.
+
+```text
+SUPABASE_PROJECT_REF_STAGING=
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_USER_A_EMAIL=
+SUPABASE_USER_A_PASSWORD=
+SUPABASE_USER_B_EMAIL=
+SUPABASE_USER_B_PASSWORD=
+```
+
+Opcionales:
+
+```text
+RLS_SMOKE_TABLE=rls_smoke_items
+RLS_SMOKE_BUCKET=agro-evidence
+RLS_SMOKE_RUN_ID=
+```
+
+## Preflight de staging
+
+El nombre visible del proyecto debe contener `staging` o `dev`.
+
+```bash
+supabase login
+supabase projects list
+```
+
+Si solo aparece `YavlGold` / `gerzlzprkarikblqxpjt`, detenerse. No se confirma staging.
+
+## PowerShell
+
+```powershell
+$env:SUPABASE_PROJECT_REF_STAGING = "<staging-project-ref>"
+pnpm guard:staging
+pnpm rls:staging:dryrun
+```
+
+Si el dry-run muestra solo migraciones esperadas:
+
+```powershell
+pnpm rls:staging:apply
+```
+
+Configurar variables del smoke test:
+
+```powershell
+$env:SUPABASE_URL = "https://<staging-project-ref>.supabase.co"
+$env:SUPABASE_ANON_KEY = "<staging-anon-key>"
+$env:SUPABASE_USER_A_EMAIL = "<qa-user-a-email>"
+$env:SUPABASE_USER_A_PASSWORD = "<qa-user-a-password>"
+$env:SUPABASE_USER_B_EMAIL = "<qa-user-b-email>"
+$env:SUPABASE_USER_B_PASSWORD = "<qa-user-b-password>"
+$env:RLS_SMOKE_TABLE = "rls_smoke_items"
+$env:RLS_SMOKE_BUCKET = "agro-evidence"
+node tools/rls-smoke-test.js
+```
+
+Cleanup best-effort:
+
+```powershell
+node tools/rls-smoke-test.js --cleanup-only
+```
+
+## Bash
+
+```bash
+export SUPABASE_PROJECT_REF_STAGING="<staging-project-ref>"
+pnpm guard:staging
+pnpm rls:staging:dryrun
+```
+
+Si el dry-run muestra solo migraciones esperadas:
+
+```bash
+pnpm rls:staging:apply
+```
+
+Configurar variables del smoke test:
+
+```bash
+export SUPABASE_URL="https://<staging-project-ref>.supabase.co"
+export SUPABASE_ANON_KEY="<staging-anon-key>"
+export SUPABASE_USER_A_EMAIL="<qa-user-a-email>"
+export SUPABASE_USER_A_PASSWORD="<qa-user-a-password>"
+export SUPABASE_USER_B_EMAIL="<qa-user-b-email>"
+export SUPABASE_USER_B_PASSWORD="<qa-user-b-password>"
+export RLS_SMOKE_TABLE="rls_smoke_items"
+export RLS_SMOKE_BUCKET="agro-evidence"
+node tools/rls-smoke-test.js
+```
+
+Cleanup best-effort:
+
+```bash
+node tools/rls-smoke-test.js --cleanup-only
+```
+
+## Interpretacion de exit codes
+
+| Exit code | Estado | Lectura |
+| --- | --- | --- |
+| `0` | PASS / CLEANUP_OK | Validacion completa o cleanup exitoso. |
+| `2` | FAIL | Fallo de seguridad: usuario A logro operar sobre datos/carpeta de usuario B, o un usuario no pudo operar sobre su propio recurso esperado. |
+| `3` | BLOQUEADO | Falta env/config, login QA falla, tabla/bucket no existe, o falta aplicar migraciones en staging confirmado. |
+
+## Resultado JSON esperado
+
+El script imprime JSON sin secrets. Campos relevantes:
+
+```json
+{
+  "ok": true,
+  "status": "PASS",
+  "project_host": "<host-only>",
+  "table": "rls_smoke_items",
+  "bucket": "agro-evidence",
+  "results": {
+    "db_select_cross_user": { "status": "PASS" },
+    "db_update_cross_user": { "status": "PASS" },
+    "db_delete_cross_user": { "status": "PASS" },
+    "db_insert_wrong_user_id": { "status": "PASS" },
+    "storage_read_own": { "status": "PASS" },
+    "storage_upload_other_folder": { "status": "PASS" },
+    "storage_read_other_folder": { "status": "PASS" }
+  }
+}
+```
+
+## GitHub Actions manual
+
+Workflow: `.github/workflows/rls-smoke-staging.yml`.
+
+Configurar estos GitHub Actions secrets en el repo, con valores de staging:
+
+```text
+SUPABASE_URL
+SUPABASE_ANON_KEY
+SUPABASE_USER_A_EMAIL
+SUPABASE_USER_A_PASSWORD
+SUPABASE_USER_B_EMAIL
+SUPABASE_USER_B_PASSWORD
+```
+
+El workflow no aplica migraciones. Solo ejecuta build y smoke test contra un staging ya preparado.
+
+## Migracion esperada
+
+La migracion `supabase/migrations/20260424101000_rls_smoke_items.sql` crea `public.rls_smoke_items`, tabla aislada para validar RLS owner-based.
+
+No se aplica hoy a remoto porque no hay staging confirmado.
+
+## Checklist para cerrar PASS
+
+1. Crear o renombrar un proyecto Supabase cuyo nombre contenga `staging` o `dev`.
+2. Confirmarlo con `supabase projects list`.
+3. Setear `SUPABASE_PROJECT_REF_STAGING`.
+4. Ejecutar `pnpm rls:staging:dryrun`.
+5. Revisar que el dry-run solo incluya migraciones esperadas.
+6. Ejecutar `pnpm rls:staging:apply`.
+7. Crear dos usuarios QA existentes en Auth del staging.
+8. Setear variables `SUPABASE_URL`, `SUPABASE_ANON_KEY` y credenciales QA A/B localmente o como GitHub Actions secrets.
+9. Ejecutar `node tools/rls-smoke-test.js`.
+10. Registrar el JSON final en la evidencia de seguridad sin secrets.
+
+## TODOs minimos
+
+- Crear o identificar STAGING real con nombre visible `staging` o `dev`.
+- Cargar secrets de staging en GitHub Actions.
+- Crear usuarios QA A/B en Auth de staging.
+- Ejecutar dry-run, apply y smoke test siguiendo este runbook.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "sb:up:ui": "supabase start --workdir . -x imgproxy,vector,logflare,edge-runtime,supavisor,mailpit",
     "sb:down": "supabase stop --workdir .",
     "sb:status": "supabase status --workdir .",
+    "guard:staging": "node tools/supabase-staging-guard.mjs",
+    "rls:staging:dryrun": "node tools/supabase-staging-guard.mjs --dry-run",
+    "rls:staging:apply": "node tools/supabase-staging-guard.mjs --apply",
     "dev:online": "pnpm -C apps/gold dev -- --mode online",
     "dev:offline": "pnpm sb:up && pnpm -C apps/gold dev -- --mode offline",
     "stop": "pnpm sb:down"

--- a/supabase/migrations/20260424101000_rls_smoke_items.sql
+++ b/supabase/migrations/20260424101000_rls_smoke_items.sql
@@ -1,0 +1,72 @@
+-- =====================================================
+-- YavlGold RLS smoke-test table
+-- Date: 2026-04-24
+--
+-- Scope:
+-- - Add an isolated table for A/B RLS validation.
+-- - Keep it unused by the application and safe for staging verification.
+-- - Apply only after the staging guard confirms a staging/dev project.
+-- =====================================================
+
+begin;
+
+create table if not exists public.rls_smoke_items (
+    id uuid primary key default gen_random_uuid(),
+    user_id uuid not null default auth.uid(),
+    label text not null,
+    created_at timestamptz not null default now(),
+    constraint rls_smoke_items_label_check
+        check (left(label, 11) = '[RLS_SMOKE]')
+);
+
+comment on table public.rls_smoke_items is
+    'Isolated table for owner-based Supabase RLS smoke tests. Not used by the app.';
+
+create index if not exists rls_smoke_items_user_id_idx
+    on public.rls_smoke_items (user_id);
+
+create index if not exists rls_smoke_items_created_at_idx
+    on public.rls_smoke_items (created_at desc);
+
+alter table public.rls_smoke_items enable row level security;
+
+grant select, insert, update, delete on public.rls_smoke_items to authenticated;
+
+drop policy if exists rls_smoke_items_select_own on public.rls_smoke_items;
+create policy rls_smoke_items_select_own
+on public.rls_smoke_items
+for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+drop policy if exists rls_smoke_items_insert_own on public.rls_smoke_items;
+create policy rls_smoke_items_insert_own
+on public.rls_smoke_items
+for insert
+to authenticated
+with check (
+    (select auth.uid()) = user_id
+    and left(label, 11) = '[RLS_SMOKE]'
+);
+
+drop policy if exists rls_smoke_items_update_own on public.rls_smoke_items;
+create policy rls_smoke_items_update_own
+on public.rls_smoke_items
+for update
+to authenticated
+using ((select auth.uid()) = user_id)
+with check (
+    (select auth.uid()) = user_id
+    and left(label, 11) = '[RLS_SMOKE]'
+);
+
+drop policy if exists rls_smoke_items_delete_own on public.rls_smoke_items;
+create policy rls_smoke_items_delete_own
+on public.rls_smoke_items
+for delete
+to authenticated
+using ((select auth.uid()) = user_id);
+
+notify pgrst, 'reload schema';
+
+commit;

--- a/tools/rls-smoke-test.js
+++ b/tools/rls-smoke-test.js
@@ -1,99 +1,215 @@
 #!/usr/bin/env node
 const { createClient } = require('@supabase/supabase-js');
 
-const required = ['SUPABASE_URL', 'SUPABASE_ANON_KEY'];
-const missing = required.filter((name) => !process.env[name]);
+const EXIT_SECURITY_FAIL = 2;
+const EXIT_BLOCKED = 3;
 
-if (missing.length > 0) {
-  console.error(`Missing required env: ${missing.join(', ')}`);
-  process.exit(2);
-}
+const requiredEnv = [
+  'SUPABASE_URL',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_USER_A_EMAIL',
+  'SUPABASE_USER_A_PASSWORD',
+  'SUPABASE_USER_B_EMAIL',
+  'SUPABASE_USER_B_PASSWORD'
+];
+
+const args = new Set(process.argv.slice(2));
+const cleanupOnly = args.has('--cleanup-only');
+const runId = process.env.RLS_SMOKE_RUN_ID || `rls-smoke-${Date.now()}`;
 
 const config = {
   url: process.env.SUPABASE_URL,
   anonKey: process.env.SUPABASE_ANON_KEY,
-  table: process.env.RLS_SMOKE_TABLE || 'agro_pending',
+  table: process.env.RLS_SMOKE_TABLE || 'rls_smoke_items',
   bucket: process.env.RLS_SMOKE_BUCKET || 'agro-evidence',
-  runId: process.env.RLS_SMOKE_RUN_ID || `rls-smoke-${Date.now()}`
+  runId
 };
 
-function decodeJwtSub(token) {
-  if (!token || token.split('.').length < 2) return null;
-  const payload = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
-  const json = Buffer.from(payload, 'base64').toString('utf8');
-  return JSON.parse(json).sub || null;
+const summary = {
+  ok: false,
+  status: 'BLOCKED',
+  timestamp: new Date().toISOString(),
+  project_host: redactHost(config.url),
+  table: config.table,
+  bucket: config.bucket,
+  runId: config.runId,
+  mode: cleanupOnly ? 'cleanup-only' : 'verify',
+  results: {}
+};
+
+class SmokeError extends Error {
+  constructor(kind, message, details = {}) {
+    super(message);
+    this.name = 'SmokeError';
+    this.kind = kind;
+    this.details = details;
+  }
 }
 
-function clientWithOptionalToken(token) {
+function redactHost(url) {
+  if (!url) return null;
+  try {
+    return new URL(url).host;
+  } catch {
+    return 'invalid-url';
+  }
+}
+
+function finish(exitCode) {
+  console.log(JSON.stringify(summary, null, 2));
+  process.exit(exitCode);
+}
+
+function record(name, status, details = {}) {
+  summary.results[name] = { status, ...details };
+}
+
+function block(message, details = {}) {
+  throw new SmokeError('blocked', message, details);
+}
+
+function securityFail(message, details = {}) {
+  throw new SmokeError('security_fail', message, details);
+}
+
+function assert(condition, message, details = {}) {
+  if (!condition) securityFail(message, details);
+}
+
+function validateEnv() {
+  const missing = requiredEnv.filter((name) => !process.env[name]);
+  if (missing.length > 0) {
+    summary.missing_env = missing;
+    block('Missing required environment variables', { missing_env: missing });
+  }
+
+  try {
+    const parsed = new URL(config.url);
+    if (!/^https?:$/.test(parsed.protocol)) {
+      block('SUPABASE_URL must use http or https');
+    }
+  } catch {
+    block('SUPABASE_URL is not a valid URL');
+  }
+}
+
+function client() {
   return createClient(config.url, config.anonKey, {
     auth: {
       persistSession: false,
       autoRefreshToken: false,
       detectSessionInUrl: false
-    },
-    global: token
-      ? { headers: { Authorization: `Bearer ${token}` } }
-      : undefined
+    }
   });
 }
 
 async function createUserSession(label) {
-  const token = process.env[`SUPABASE_USER_${label}_ACCESS_TOKEN`];
-  if (token) {
-    const client = clientWithOptionalToken(token);
-    return { client, user: { id: decodeJwtSub(token) }, label };
-  }
-
   const email = process.env[`SUPABASE_USER_${label}_EMAIL`];
   const password = process.env[`SUPABASE_USER_${label}_PASSWORD`];
-  if (!email || !password) {
-    throw new Error(
-      `Missing credentials for user ${label}. Provide SUPABASE_USER_${label}_ACCESS_TOKEN or SUPABASE_USER_${label}_EMAIL/PASSWORD.`
-    );
+  const supabase = client();
+  const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+
+  if (error) {
+    block(`User ${label} login failed`, { supabase_error: error.message });
   }
 
-  const client = clientWithOptionalToken();
-  const { data, error } = await client.auth.signInWithPassword({ email, password });
-  if (error) throw new Error(`User ${label} login failed: ${error.message}`);
-  return { client, user: data.user, label };
+  if (!data.user?.id) {
+    block(`User ${label} id unavailable after login`);
+  }
+
+  return { client: supabase, user: data.user, label };
 }
 
-function assert(condition, message) {
-  if (!condition) throw new Error(message);
+function isMissingSmokeTable(error) {
+  const message = String(error?.message || '').toLowerCase();
+  const code = String(error?.code || '').toLowerCase();
+  return (
+    code === '42p01'
+    || code === 'pgrst205'
+    || message.includes('could not find the table')
+    || message.includes('schema cache')
+    || message.includes(`relation "public.${config.table}" does not exist`)
+  );
 }
 
-function rowPayload(userId, label) {
+function isMissingSmokeColumn(error) {
+  const message = String(error?.message || '').toLowerCase();
+  const code = String(error?.code || '').toLowerCase();
+  return code === '42703' || code === 'pgrst204' || message.includes('could not find');
+}
+
+function smokeRow(userId, label) {
   return {
     user_id: userId,
-    concepto: `${config.runId}-${label}`,
-    cliente: `rls-smoke-${label}`,
-    monto: 1,
-    currency: 'USD',
-    transfer_state: 'active'
+    label: `[RLS_SMOKE] ${config.runId} ${label}`
   };
 }
 
-async function insertRow(session, payload) {
+async function insertSmokeRow(session, payload, resultName) {
   const { data, error } = await session.client
     .from(config.table)
     .insert(payload)
-    .select('id,user_id')
+    .select('id,user_id,label')
     .single();
 
-  if (error) throw new Error(`${session.label} insert failed on ${config.table}: ${error.message}`);
+  if (error) {
+    if (isMissingSmokeTable(error) || isMissingSmokeColumn(error)) {
+      block('Smoke table is unavailable. Apply the rls_smoke_items migration in confirmed staging first.', {
+        table: config.table,
+        supabase_error: error.message
+      });
+    }
+    securityFail(`${session.label} could not insert own smoke row`, { supabase_error: error.message });
+  }
+
+  record(resultName, 'PASS');
   return data;
 }
 
-async function expectDeniedOrNoRows(operation, description) {
-  const { data, error } = await operation();
-  const rowCount = Array.isArray(data) ? data.length : data ? 1 : 0;
-  assert(Boolean(error) || rowCount === 0, `${description} unexpectedly succeeded`);
-  return { blocked: true, error: error?.message || null, rows: rowCount };
+async function expectOwnRead(session, rowId) {
+  const { data, error } = await session.client
+    .from(config.table)
+    .select('id,user_id')
+    .eq('id', rowId);
+
+  if (error) securityFail('User could not read own smoke row', { supabase_error: error.message });
+  assert(Array.isArray(data) && data.length === 1, 'User could not read own smoke row');
+  record('db_select_own', 'PASS');
 }
 
-async function cleanupRow(session, id) {
-  if (!id) return;
-  await session.client.from(config.table).delete().eq('id', id);
+async function expectBlocked(operation, resultName, failMessage) {
+  const { data, error } = await operation();
+  const rowCount = Array.isArray(data) ? data.length : data ? 1 : 0;
+
+  if (!error && rowCount > 0) {
+    securityFail(failMessage, { rows: rowCount });
+  }
+
+  record(resultName, 'PASS', {
+    blocked_by: error ? 'error' : 'rls_zero_rows',
+    rows: rowCount
+  });
+}
+
+async function cleanupRows(session, rowIds = []) {
+  const ids = rowIds.filter(Boolean);
+  if (ids.length > 0) {
+    await session.client.from(config.table).delete().in('id', ids);
+  }
+}
+
+async function cleanupRowsByMarker(session) {
+  const { data, error } = await session.client
+    .from(config.table)
+    .delete()
+    .like('label', '[RLS_SMOKE]%')
+    .select('id');
+
+  if (error && !isMissingSmokeTable(error)) {
+    return { error: error.message, rows: 0 };
+  }
+
+  return { rows: Array.isArray(data) ? data.length : 0 };
 }
 
 async function storageUpload(session, path, label) {
@@ -104,89 +220,160 @@ async function storageUpload(session, path, label) {
   });
 }
 
+function isMissingBucket(error) {
+  const message = String(error?.message || '').toLowerCase();
+  return message.includes('bucket not found') || message.includes('not found');
+}
+
 async function storageRemove(session, paths) {
-  if (!paths.length) return;
-  await session.client.storage.from(config.bucket).remove(paths);
+  const uniquePaths = [...new Set(paths.filter(Boolean))];
+  if (uniquePaths.length === 0) return;
+  await session.client.storage.from(config.bucket).remove(uniquePaths);
+}
+
+async function cleanupStorageSmokeFiles(session) {
+  const prefix = `${session.user.id}/agro/income`;
+  const { data, error } = await session.client.storage.from(config.bucket).list(prefix, { limit: 100 });
+
+  if (error) {
+    return { error: error.message, files: 0 };
+  }
+
+  const paths = (data || [])
+    .filter((entry) => entry.name && entry.name.includes('rls-smoke-'))
+    .map((entry) => `${prefix}/${entry.name}`);
+
+  await storageRemove(session, paths);
+  return { files: paths.length };
+}
+
+async function runCleanupOnly(a, b) {
+  const [aRows, bRows, aFiles, bFiles] = await Promise.all([
+    cleanupRowsByMarker(a),
+    cleanupRowsByMarker(b),
+    cleanupStorageSmokeFiles(a),
+    cleanupStorageSmokeFiles(b)
+  ]);
+
+  record('cleanup_user_a_rows', 'PASS', aRows);
+  record('cleanup_user_b_rows', 'PASS', bRows);
+  record('cleanup_user_a_storage', 'PASS', aFiles);
+  record('cleanup_user_b_storage', 'PASS', bFiles);
+
+  summary.ok = true;
+  summary.status = 'CLEANUP_OK';
+  finish(0);
 }
 
 async function run() {
+  validateEnv();
+
   const a = await createUserSession('A');
   const b = await createUserSession('B');
 
-  assert(a.user?.id, 'User A id unavailable');
-  assert(b.user?.id, 'User B id unavailable');
   assert(a.user.id !== b.user.id, 'Users A and B must be different accounts');
 
-  const results = [];
+  if (cleanupOnly) {
+    await runCleanupOnly(a, b);
+    return;
+  }
+
   let aRow = null;
   let bRow = null;
   const aPath = `${a.user.id}/agro/income/${config.runId}-a.txt`;
   const bPath = `${b.user.id}/agro/income/${config.runId}-b.txt`;
-  const crossPath = `${b.user.id}/agro/income/${config.runId}-cross.txt`;
+  const crossPath = `${b.user.id}/agro/income/${config.runId}-a-to-b.txt`;
 
   try {
-    aRow = await insertRow(a, rowPayload(a.user.id, 'A'));
-    bRow = await insertRow(b, rowPayload(b.user.id, 'B'));
-    results.push(['db_insert_own', 'ok']);
+    aRow = await insertSmokeRow(a, smokeRow(a.user.id, 'A'), 'db_insert_own_a');
+    bRow = await insertSmokeRow(b, smokeRow(b.user.id, 'B'), 'db_insert_own_b');
 
-    const ownRead = await a.client.from(config.table).select('id,user_id').eq('id', aRow.id);
-    assert(!ownRead.error && ownRead.data?.length === 1, 'User A could not read own row');
-    results.push(['db_select_own', 'ok']);
+    await expectOwnRead(a, aRow.id);
 
-    const crossRead = await a.client.from(config.table).select('id,user_id').eq('id', bRow.id);
-    assert(!crossRead.error && crossRead.data.length === 0, 'User A read user B row');
-    results.push(['db_select_cross_user', 'blocked']);
-
-    await expectDeniedOrNoRows(
-      () => a.client.from(config.table).update({ concepto: `${config.runId}-cross-update` }).eq('id', bRow.id).select('id'),
-      'User A update of user B row'
+    await expectBlocked(
+      () => a.client.from(config.table).select('id,user_id').eq('id', bRow.id),
+      'db_select_cross_user',
+      'User A read User B smoke row'
     );
-    results.push(['db_update_cross_user', 'blocked']);
 
-    await expectDeniedOrNoRows(
+    await expectBlocked(
+      () => a.client.from(config.table).update({ label: `[RLS_SMOKE] ${config.runId} cross-update` }).eq('id', bRow.id).select('id'),
+      'db_update_cross_user',
+      'User A updated User B smoke row'
+    );
+
+    await expectBlocked(
       () => a.client.from(config.table).delete().eq('id', bRow.id).select('id'),
-      'User A delete of user B row'
+      'db_delete_cross_user',
+      'User A deleted User B smoke row'
     );
-    results.push(['db_delete_cross_user', 'blocked']);
 
-    await expectDeniedOrNoRows(
-      () => a.client.from(config.table).insert(rowPayload(b.user.id, 'A-as-B')).select('id'),
-      'User A insert with user B user_id'
+    await expectBlocked(
+      () => a.client.from(config.table).insert(smokeRow(b.user.id, 'A-as-B')).select('id'),
+      'db_insert_wrong_user_id',
+      'User A inserted a smoke row with User B user_id'
     );
-    results.push(['db_insert_wrong_user_id', 'blocked']);
 
     const ownUpload = await storageUpload(a, aPath, 'A');
-    if (ownUpload.error) throw new Error(`User A own storage upload failed: ${ownUpload.error.message}`);
-    results.push(['storage_upload_own', 'ok']);
+    if (ownUpload.error) {
+      if (isMissingBucket(ownUpload.error)) {
+        block('Storage bucket is unavailable. Apply storage migration in confirmed staging first.', {
+          bucket: config.bucket,
+          supabase_error: ownUpload.error.message
+        });
+      }
+      securityFail('User A could not upload to own storage folder', { supabase_error: ownUpload.error.message });
+    }
+    record('storage_upload_own', 'PASS');
+
+    const ownDownload = await a.client.storage.from(config.bucket).download(aPath);
+    if (ownDownload.error) {
+      securityFail('User A could not read own storage object', { supabase_error: ownDownload.error.message });
+    }
+    record('storage_read_own', 'PASS');
 
     const bUpload = await storageUpload(b, bPath, 'B');
-    if (bUpload.error) throw new Error(`User B own storage upload failed: ${bUpload.error.message}`);
-    results.push(['storage_upload_b_own_setup', 'ok']);
+    if (bUpload.error) {
+      if (isMissingBucket(bUpload.error)) {
+        block('Storage bucket is unavailable. Apply storage migration in confirmed staging first.', {
+          bucket: config.bucket,
+          supabase_error: bUpload.error.message
+        });
+      }
+      securityFail('User B could not upload to own storage folder', { supabase_error: bUpload.error.message });
+    }
+    record('storage_upload_b_own_setup', 'PASS');
 
     const crossUpload = await storageUpload(a, crossPath, 'A-to-B');
-    assert(Boolean(crossUpload.error), 'User A uploaded into user B storage prefix');
-    results.push(['storage_upload_cross_prefix', 'blocked']);
+    if (!crossUpload.error) {
+      securityFail('User A uploaded into User B storage folder');
+    }
+    record('storage_upload_other_folder', 'PASS', { blocked_by: 'error' });
 
     const crossDownload = await a.client.storage.from(config.bucket).download(bPath);
-    assert(Boolean(crossDownload.error), 'User A downloaded user B storage object');
-    results.push(['storage_read_cross_prefix', 'blocked']);
+    if (!crossDownload.error) {
+      securityFail('User A downloaded User B storage object');
+    }
+    record('storage_read_other_folder', 'PASS', { blocked_by: 'error' });
   } finally {
-    await cleanupRow(a, aRow?.id);
-    await cleanupRow(b, bRow?.id);
+    await cleanupRows(a, [aRow?.id]);
+    await cleanupRows(b, [bRow?.id]);
     await storageRemove(a, [aPath]);
-    await storageRemove(b, [bPath]);
+    await storageRemove(b, [bPath, crossPath]);
   }
 
-  console.log(JSON.stringify({
-    ok: true,
-    table: config.table,
-    bucket: config.bucket,
-    runId: config.runId,
-    results: Object.fromEntries(results)
-  }, null, 2));
+  summary.ok = true;
+  summary.status = 'PASS';
+  finish(0);
 }
 
 run().catch((error) => {
-  console.error(JSON.stringify({ ok: false, error: error.message }, null, 2));
-  process.exit(1);
+  const isSmoke = error instanceof SmokeError;
+  summary.ok = false;
+  summary.status = isSmoke && error.kind === 'security_fail' ? 'FAIL' : 'BLOCKED';
+  summary.error = error.message || 'Unknown smoke-test error';
+  if (error.details && Object.keys(error.details).length > 0) {
+    summary.details = error.details;
+  }
+  finish(isSmoke && error.kind === 'security_fail' ? EXIT_SECURITY_FAIL : EXIT_BLOCKED);
 });

--- a/tools/supabase-staging-guard.mjs
+++ b/tools/supabase-staging-guard.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const STAGING_NAME_PATTERN = /staging|dev/i;
+const REQUIRED_REF_ENV = 'SUPABASE_PROJECT_REF_STAGING';
+
+function stripAnsi(value) {
+  return String(value || '').replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function fail(message, details = []) {
+  console.error(`staging-guard: BLOCKED - ${message}`);
+  for (const detail of details) {
+    console.error(`- ${detail}`);
+  }
+  process.exit(1);
+}
+
+function parseProjectsJson(rawOutput) {
+  const clean = stripAnsi(rawOutput).trim();
+  const start = clean.indexOf('[');
+  const end = clean.lastIndexOf(']');
+  if (start === -1 || end === -1 || end < start) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(clean.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+function listProjects() {
+  const result = spawnSync('supabase', ['projects', 'list', '--output', 'json'], {
+    encoding: 'utf8',
+    shell: false
+  });
+
+  if (result.error) {
+    fail('could not execute Supabase CLI', [result.error.message]);
+  }
+
+  if (result.status !== 0) {
+    fail('supabase projects list failed', [
+      stripAnsi(result.stderr || result.stdout).trim() || `exit code ${result.status}`
+    ]);
+  }
+
+  const projects = parseProjectsJson(result.stdout) || parseProjectsJson(result.stderr);
+  if (!Array.isArray(projects)) {
+    fail('could not parse supabase projects list output');
+  }
+
+  return projects.map((project) => ({
+    ref: String(project.ref || project.id || '').trim(),
+    name: String(project.name || '').trim()
+  })).filter((project) => project.ref && project.name);
+}
+
+function runSupabase(args) {
+  const result = spawnSync('supabase', args, {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+    shell: false
+  });
+
+  if (result.error) {
+    fail(`could not execute supabase ${args.join(' ')}`, [result.error.message]);
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status || 1);
+  }
+}
+
+function usage() {
+  return [
+    'usage: node tools/supabase-staging-guard.mjs [--dry-run|--apply]',
+    '',
+    `required env: ${REQUIRED_REF_ENV}`,
+    'policy: target project name must contain staging or dev'
+  ].join('\n');
+}
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const apply = args.includes('--apply');
+
+if (args.includes('--help') || args.includes('-h')) {
+  console.log(usage());
+  process.exit(0);
+}
+
+if (dryRun && apply) {
+  fail('choose only one mode: --dry-run or --apply');
+}
+
+const targetRef = String(process.env[REQUIRED_REF_ENV] || '').trim();
+if (!targetRef) {
+  fail(`missing ${REQUIRED_REF_ENV}`, [
+    'Set it locally to the confirmed staging/dev project ref.',
+    'Do not use production refs or commit this value.'
+  ]);
+}
+
+const projects = listProjects();
+const target = projects.find((project) => project.ref === targetRef);
+const knownProjects = projects.map((project) => `${project.name} (${project.ref})`);
+
+if (!target) {
+  fail('target project ref was not found in supabase projects list', [
+    `target ref: ${targetRef}`,
+    `known projects: ${knownProjects.length ? knownProjects.join(', ') : 'none'}`
+  ]);
+}
+
+if (!STAGING_NAME_PATTERN.test(target.name)) {
+  fail('target project name does not confirm staging/dev', [
+    `target name: ${target.name}`,
+    `target ref: ${target.ref}`,
+    'Rename/create a staging project whose name contains staging or dev before linking or pushing.'
+  ]);
+}
+
+console.log(`staging-guard: PASS - confirmed ${target.name} (${target.ref})`);
+
+if (dryRun || apply) {
+  runSupabase(['link', '--project-ref', target.ref, '--workdir', '.']);
+  runSupabase(['db', 'push', '--workdir', '.', ...(dryRun ? ['--dry-run'] : [])]);
+}


### PR DESCRIPTION
## Summary
- Add a Supabase staging guard that blocks link/push unless `SUPABASE_PROJECT_REF_STAGING` points to a project whose visible name contains `staging` or `dev`.
- Move DB smoke validation to isolated `public.rls_smoke_items` migration so the A/B test does not create records in product tables.
- Improve `tools/rls-smoke-test.js` with strict env preflight, JSON output, exit codes, own/cross DB checks, own/cross Storage checks, and `--cleanup-only`.
- Add a manual GitHub Actions workflow for staging smoke verification and runbooks for local/CI execution.
- Remove literal git-directive residue from docs discovered by the requested scan.

## Verification
- `git diff --check`
- `rg -n "::git-" .` returned no matches
- `pnpm guard:staging` blocks cleanly without `SUPABASE_PROJECT_REF_STAGING`
- `node --check tools/rls-smoke-test.js`
- `node tools/rls-smoke-test.js` blocks cleanly with exit code 3 when required env vars are missing
- `pnpm build:gold` passes; local Node 25 vs engine Node 20 warning remains expected
- Secret scans were run without printing values; matches are expected variable names/placeholders/docs/SQL role grants